### PR TITLE
Fixed PHP notice caused by direct access to product type property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.17.0",
+  "version": "1.17.1",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.17.0
+  Version: 1.17.1
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -83,10 +83,10 @@ class Admin {
   public static function updateSalePercentage($check, $object_id, $meta_key, $meta_value) {
     if ($meta_key === '_regular_price' || $meta_key === '_sale_price') {
       $product = wc_get_product($object_id);
-      if ($product->product_type === 'variation') {
+      if ($product->get_type() === 'variation') {
         static::saveSalePercentage($product->get_parent_id(), $product->parent->post);
       }
-      elseif ($product->product_type === 'simple') {
+      elseif ($product->get_type() === 'simple') {
         static::saveSalePercentage($product->get_id(), $product->post);
       }
     }


### PR DESCRIPTION
Direct access to product object properties like `product_type` is deprecated. Methods like `is_type()` or `get_type()`should be used.