### PR TITLE
Fixed products discount percentage was not displayed in instant search results panel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.18.0",
+  "version": "1.18.1",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.18.0
+  Version: 1.18.1
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -57,6 +57,9 @@ class Plugin {
       Plugin::register_acf();
     }
 
+    // Changes sale flash label to display sale percentage, also on instant search results panel.
+    add_filter('woocommerce_sale_flash', __NAMESPACE__ . '\WooCommerce::woocommerce_sale_flash', 10, 3);
+
     if (is_admin()) {
       return;
     }
@@ -93,8 +96,6 @@ class Plugin {
     // Adds custom sort by sale percentage option.
     add_filter('woocommerce_default_catalog_orderby_options', __NAMESPACE__ . '\WooCommerce::orderbySalePercentage');
     add_filter('woocommerce_catalog_orderby', __NAMESPACE__ . '\WooCommerce::orderbySalePercentage');
-    // Changes sale flash label to display sale percentage.
-    add_filter('woocommerce_sale_flash', __NAMESPACE__ . '\WooCommerce::woocommerce_sale_flash', 10, 3);
 
     // Displays sale price as regular price if custom field is checked.
     add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_price_html', 10, 2);


### PR DESCRIPTION
Related task:
- [Bug: missing sale percentage in instant search results](https://app.asana.com/0/inbox/383242129844222/999586903822110/999881832341140)