### PR TITLE
Fixed sale percentage has wrong primitive type.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -108,7 +108,7 @@ class Admin {
         $where = "WHERE p.post_type = 'product' AND p.ID = $post_id";
       }
 
-      $sale_percentage = $wpdb->get_var("SELECT FLOOR((regular_price.meta_value - sale_price.meta_value) / regular_price.meta_value * 100) AS sale_percentage
+      $sale_percentage = (int) $wpdb->get_var("SELECT FLOOR((regular_price.meta_value - sale_price.meta_value) / regular_price.meta_value * 100) AS sale_percentage
         FROM wp_posts p
         LEFT JOIN wp_postmeta regular_price ON regular_price.post_id = p.ID AND regular_price.meta_key = '_regular_price'
         LEFT JOIN wp_postmeta sale_price ON sale_price.post_id = p.ID AND sale_price.meta_key = '_sale_price'


### PR DESCRIPTION
### Ticket
- [Related Ticket](https://app.asana.com/0/30156186242982/1106570301274255/f)

### Description
- `get_var()` returns a `string` primitive while the conditional below will check for an `int` and therefore not resets the `_sale_percentage` to `0`.

  Thus plenty of products with a `_sale_percentage` of `100` exists and therefore the sorting will fail somehow.

- Wrong products can be updated via this SQL statement: 
  ```sql
  UPDATE wp_postmeta SET meta_value = 0 WHERE meta_key = '_sale_percentage' AND meta_value = 100;
  ```