### PR TITLE
Fixed PHP fatal error when retrieving simple product attributes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.21.1",
+  "version": "1.21.2",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.21.1
+  Version: 1.21.2
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -566,7 +566,13 @@ class WooCommerce {
     if ($parent_id = $product->get_parent_id()) {
       $product = wc_get_product($parent_id);
     }
-    $variation_attributes = $product->get_variation_attributes();
+
+    if ($product->get_type() === 'variable') {
+      $variation_attributes = $product->get_variation_attributes();
+    }
+    else {
+      $variation_attributes = [];
+    }
     $attributes = $product->get_attributes();
 
     foreach ($attributes as $key => $attribute) {


### PR DESCRIPTION
### Ticket
- [Mails: all product attributes are shown](https://app.asana.com/0/383242129844224/1115195838885601)

### Description
- PHP Fatal error

> Got error 'PHP message: PHP Fatal error:  Uncaught Error: Call to undefined method WC_Product_Simple::get_variation_attributes() in /var/www/vhosts/gartenmoebelcompany.de/htdocs/wp-content/p      lugins/shop-standards/src/WooCommerce.php:569

