### PR TITLE
Fixed admin hooks are not invoked for cron jobs.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -39,9 +39,6 @@ register_uninstall_hook(__FILE__, __NAMESPACE__ . '\Schema::uninstall');
 
 add_action('plugins_loaded', __NAMESPACE__ . '\Plugin::loadTextdomain');
 add_action('admin_init', __NAMESPACE__ . '\Admin::init');
-if (defined('DOING_CRON') && DOING_CRON) {
-  add_action('init', __NAMESPACE__ . '\Admin::init');
-}
 add_action('init', __NAMESPACE__ . '\Plugin::preInit', 0);
 add_action('init', __NAMESPACE__ . '\Plugin::init', 20);
 

--- a/plugin.php
+++ b/plugin.php
@@ -39,6 +39,9 @@ register_uninstall_hook(__FILE__, __NAMESPACE__ . '\Schema::uninstall');
 
 add_action('plugins_loaded', __NAMESPACE__ . '\Plugin::loadTextdomain');
 add_action('admin_init', __NAMESPACE__ . '\Admin::init');
+if (defined('DOING_CRON') && DOING_CRON) {
+  add_action('init', __NAMESPACE__ . '\Admin::init');
+}
 add_action('init', __NAMESPACE__ . '\Plugin::preInit', 0);
 add_action('init', __NAMESPACE__ . '\Plugin::init', 20);
 

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -25,23 +25,13 @@ class Admin {
    * @implements admin_init
    */
   public static function init() {
-    // Ensures new product are saved before updating its meta data.
-    add_action('woocommerce_process_product_meta', __NAMESPACE__ . '\WooCommerce::saveNewProductBeforeMetaUpdate', 1);
-
-    // Updates product delivery time with the lowest delivery time between its own variations.
-    add_action('updated_post_meta', __CLASS__ . '::updateProductDeliveryTime', 10, 3);
-    // Updates sale percentage when regular price or sale price are updated.
-    add_action('updated_post_meta', __CLASS__ . '::updateSalePercentage', 10, 4);
-
     // Adds custom fields for single products.
     add_action('woocommerce_product_options_general_product_data',  __NAMESPACE__ . '\WooCommerce::woocommerce_product_options_general_product_data');
     // Appends product notes custom field as the last field in the product general options section.
     add_action('woocommerce_product_options_general_product_data', __NAMESPACE__ . '\WooCommerce::productNotesCustomField', 999);
-    add_action('woocommerce_process_product_meta', __NAMESPACE__ . '\WooCommerce::woocommerce_process_product_meta');
 
     // Adds products variations custom fields.
     add_action('woocommerce_product_after_variable_attributes', __NAMESPACE__ . '\WooCommerce::woocommerce_product_after_variable_attributes', 10, 3);
-    add_action('woocommerce_save_product_variation', __NAMESPACE__ . '\WooCommerce::woocommerce_save_product_variation', 10, 2);
 
     // Defines plugin configuration settings.
     if (!isset(static::$pluginSettings)) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -63,6 +63,16 @@ class Plugin {
     // Displays sale price as regular price if custom field is checked.
     add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_price_html', 10, 2);
 
+    // Ensures new product are saved before updating its meta data.
+    add_action('woocommerce_process_product_meta', __NAMESPACE__ . '\WooCommerce::saveNewProductBeforeMetaUpdate', 1);
+    // Updates product delivery time with the lowest delivery time between its own variations.
+    add_action('updated_post_meta', __NAMESPACE__ . '\Admin::updateProductDeliveryTime', 10, 3);
+    // Updates sale percentage when regular price or sale price are updated.
+    add_action('updated_post_meta', __NAMESPACE__ . '\Admin::updateSalePercentage', 10, 4);
+
+    add_action('woocommerce_process_product_meta', __NAMESPACE__ . '\WooCommerce::woocommerce_process_product_meta');
+    add_action('woocommerce_save_product_variation', __NAMESPACE__ . '\WooCommerce::woocommerce_save_product_variation', 10, 2);
+
     if (is_admin()) {
       return;
     }


### PR DESCRIPTION
### Description
- When cron jobs are run, the registered plugin admin hooks are not invoked which prevents some desired behaviour if, for example, posts are updated.
- To prevent this, we call the admin init method manually when doing cron.
