### PR TITLE
Fixed fatal error thrown when avanced-custom-fields plugin is not installed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.24.4",
+  "version": "1.24.5",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.24.4
+  Version: 1.24.5
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -278,7 +278,7 @@ class WooCommerce {
    * Displays order notice for products that must not be sold online.
    */
   public static function woocommerce_single_product_summary() {
-    if (empty($notice = get_field('acf_hide_add_to_cart_product_notice', 'option')) || empty($product = wc_get_product())) {
+    if (function_exists('get_field') && empty($notice = get_field('acf_hide_add_to_cart_product_notice', 'option')) || empty($product = wc_get_product())) {
       return;
     }
     $product_id = $product->get_id();
@@ -292,7 +292,7 @@ class WooCommerce {
    * Checks whether a given post has a given term.
    */
   public static function productHasSpecificTaxonomyTerm($post_id, $taxonomy_name) {
-    if (class_exists('acf') && $excluded_terms = get_field('acf_hide_add_to_cart_' . $taxonomy_name, 'option')) {
+    if (function_exists('get_field') && $excluded_terms = get_field('acf_hide_add_to_cart_' . $taxonomy_name, 'option')) {
       return has_term($excluded_terms, $taxonomy_name, $post_id);
     }
   }


### PR DESCRIPTION
### Ticket
- [Fatal error in plugin shop-standards](https://app.asana.com/0/809933051638353/1134306736653764/f)

### Description
- PHP fatal error were still happening.
