### PR TITLE
Fixed product delivery time was not updated with the lowest value from its variations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.28.0",
+  "version": "1.28.1",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.28.0
+  Version: 1.28.1
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -45,24 +45,44 @@ class Admin {
     }
 
     $product = wc_get_product($object_id);
-    if ($product->is_type('variation')) {
-      $variation_deliveries_ranges = [];
-
-      $parent_product = wc_get_product($product->get_parent_id());
-      foreach ($parent_product->get_children() as $variation) {
-        $variation_term_id = get_post_meta($variation, '_lieferzeit', TRUE);
-        $variation_term_slug = get_term($variation_term_id)->slug;
-        // Matches every digits in the delivery time term slug.
-        preg_match('/(\d+)/', $variation_term_slug, $variation_delivery_days);
-        array_shift($variation_delivery_days);
-        if ($variation_delivery_days) {
-          $variation_deliveries_ranges[$variation_term_id] = $variation_delivery_days;
-        }
-      }
-
-      asort($variation_deliveries_ranges);
-      update_post_meta($product->get_parent_id(), $meta_key, array_keys($variation_deliveries_ranges)[0]);
+    if (!in_array($product->get_type(), ['variation', 'variable'])) {
+      return;
     }
+
+    if ($product->is_type('variable')) {
+      $parent_product = $product;
+    }
+    elseif ($product->is_type('variation')) {
+      $parent_product = wc_get_product($product->get_parent_id());
+    }
+    $shortest_delivery_time = static::getProductShortestDeliveryTime($parent_product);
+    update_post_meta($parent_product->get_id(), $meta_key, $shortest_delivery_time);
+  }
+
+  /**
+   * Retrieves the shortest delivery time from the variations of a product.
+   *
+   * @param \WC_Product $product
+   *   Variable product.
+   *
+   * @return string
+   *   Shortest delivery time.
+   */
+  public static function getProductShortestDeliveryTime(\WC_Product $product): string {
+    $variation_deliveries_ranges = [];
+
+    foreach ($product->get_children() as $variation) {
+      $variation_term_id = get_post_meta($variation, '_lieferzeit', TRUE);
+      $variation_term_slug = get_term($variation_term_id)->slug;
+      // Matches every digits in the delivery time term slug.
+      preg_match('/(\d+)/', $variation_term_slug, $variation_delivery_days);
+      array_shift($variation_delivery_days);
+      if ($variation_delivery_days) {
+        $variation_deliveries_ranges[$variation_term_id] = $variation_delivery_days;
+      }
+    }
+    asort($variation_deliveries_ranges);
+    return array_keys($variation_deliveries_ranges)[0];
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [Shortest delivery time on the overview page not correct](https://app.asana.com/0/383242129844224/1127550128825839)

### Description
- Parent product delivery time is not updated with the lowest value from its variations when saved using the edit product page "Update" button.