### PR TITLE
Fixed PHP error when product brand taxonomy does not exist.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.29.1",
+  "version": "1.29.2",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.29.1
+  Version: 1.29.2
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -117,7 +117,8 @@ class Seo {
   public static function getProductBrand($data) {
     global $product;
 
-    if ($brand = get_the_terms($product->get_id(), apply_filters(Plugin::PREFIX . '_product_brand_taxonomy', 'pa_marken'))) {
+    $brand = get_the_terms($product->get_id(), apply_filters(Plugin::PREFIX . '_product_brand_taxonomy', 'pa_marken'));
+    if ($brand && !is_wp_error($brand)) {
       $data['brand'] = $brand[0]->name;
     }
 


### PR DESCRIPTION
### Ticket
- []()

### Description
- A PHP error is thrown when product brand taxonomy does not exist.

> Fatal error: Uncaught Error: Cannot use object of type WP_Error as array in /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-content/plugins/shop-standards/src/Seo.php:121 Stack trace: #0 /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-includes/class-wp-hook.php(288): Netzstrategen\ShopStandards\Seo::getProductBrand(Array) #1 /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-includes/plugin.php(208): WP_Hook->apply_filters(Array, Array) #2 /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-content/plugins/woocommerce/includes/class-wc-structured-data.php(321): apply_filters('woocommerce_str...', Array, Object(WC_Product_Simple)) #3 /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-includes/class-wp-hook.php(286): WC_Structured_Data->generate_product_data(Object(WC_Product_Simple)) #4 /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters(NULL, Array) #5 /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-includes/plugin.php(465): WP_Hook->do_action(Array) #6 /var/www/vhosts/stage.nutr. in /var/www/vhosts/stage.nutr.netz.rocks/htdocs/wp-content/plugins/shop-standards/src/Seo.php on line 121

