### PR TITLE
Fixed incorrect notice when zero stock but backorder possible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.30.1",
+  "version": "1.30.2",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.30.1
+  Version: 1.30.2
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -134,10 +134,10 @@ class WooCommerce {
     if ($product->is_type('variation')) {
       $low_stock_amount = get_post_meta($product->get_parent_id(), '_low_stock_amount', TRUE);
     }
-    elseif ($product->get_low_stock_amount()) {
+    else {
       $low_stock_amount = $product->get_low_stock_amount();
     }
-    else {
+    if (!$low_stock_amount) {
       $low_stock_amount = get_option('woocommerce_notify_low_stock_amount');
     }
 
@@ -158,6 +158,7 @@ class WooCommerce {
         $stock['class'] = 'in-stock';
       }
     }
+
     return $stock;
   }
 

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -136,7 +136,7 @@ class WooCommerce {
     else {
       $low_stock_amount = $product->get_low_stock_amount();
     }
-    if ($low_stock_amount === '') {
+    if (empty($low_stock_amount)) {
       $low_stock_amount = get_option('woocommerce_notify_low_stock_amount');
     }
 
@@ -146,9 +146,10 @@ class WooCommerce {
     // is_in_stock() returns true if stock level is zero but backorders allowed.
     // If stock level below threshold (but above zero), show "Only x in stock".
     // Otherwise, show "In stock" (not shown by WooCommerce by default).
+    $product_stock_quantity = $product->get_stock_quantity();
     if ($product->is_in_stock()) {
-      if ($show_low_stock_amount && $product->get_stock_quantity() > 0 && $product->get_stock_quantity() <= $low_stock_amount) {
-        $stock['availability'] = sprintf(__('Only %s in stock', Plugin::L10N), $product->get_stock_quantity());
+      if ($show_low_stock_amount && $product_stock_quantity > 0 && $product_stock_quantity <= $low_stock_amount) {
+        $stock['availability'] = sprintf(__('Only %s in stock', Plugin::L10N), $product_stock_quantity);
         $stock['class'] = 'low-stock';
       }
       else {

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -128,15 +128,22 @@ class WooCommerce {
     $product->set_manage_stock('yes');
     $product->set_backorders('yes');
 
-    // Low stock level is only set on parent product.
+    // Low stock level is set globally or on parent product.
     // If product is a variation then manually get the value based on parent ID.
+    // If parent product doesn't have value set then use global value.
     if ($product->is_type('variation')) {
       $low_stock_amount = get_post_meta($product->get_parent_id(), '_low_stock_amount', TRUE);
     }
-    else {
+    elseif ($product->get_low_stock_amount()) {
       $low_stock_amount = $product->get_low_stock_amount();
     }
+    else {
+      $low_stock_amount = get_option('woocommerce_notify_low_stock_amount');
+    }
 
+    // If stock level is zero but backorders allowed, show "Deliverable".
+    // If stock level below threshold (but above zero), show "Only x in stock".
+    // Otherwise, show in stock or out of stock notice as expected.
     if ($product->managing_stock() && $product->backorders_allowed()) {
       if (!$product->is_in_stock()) {
         $stock['availability'] = __('Out of stock', 'woocommerce');

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -128,28 +128,26 @@ class WooCommerce {
     $product->set_manage_stock('yes');
     $product->set_backorders('yes');
 
-    // Low stock level is set globally or on parent product.
-    // If product is a variation then manually get the value based on parent ID.
-    // If parent product doesn't have value set then use global value.
+    // If low stock threshold is not set at product level, get global option.
     if ($product->is_type('variation')) {
-      $low_stock_amount = get_post_meta($product->get_parent_id(), '_low_stock_amount', TRUE);
+      $parent_product = wc_get_product($product->get_parent_id());
+      $low_stock_amount = $parent_product->get_low_stock_amount();
     }
     else {
       $low_stock_amount = $product->get_low_stock_amount();
     }
-    if (!$low_stock_amount) {
+    if ($low_stock_amount === '') {
       $low_stock_amount = get_option('woocommerce_notify_low_stock_amount');
     }
 
-    // If stock level is zero but backorders allowed, show "Deliverable".
+    // Check global "Stock display format" option is set to show low stock notices.
+    $show_low_stock_amount = get_option('woocommerce_stock_format') === 'low_amount';
+
+    // is_in_stock() returns true if stock level is zero but backorders allowed.
     // If stock level below threshold (but above zero), show "Only x in stock".
-    // Otherwise, show in stock or out of stock notice as expected.
-    if ($product->managing_stock() && $product->backorders_allowed()) {
-      if (!$product->is_in_stock()) {
-        $stock['availability'] = __('Out of stock', 'woocommerce');
-        $stock['class'] = 'out-of-stock';
-      }
-      elseif ($product->get_stock_quantity() > 0 && $product->get_stock_quantity() <= $low_stock_amount) {
+    // Otherwise, show "In stock" (not shown by WooCommerce by default).
+    if ($product->is_in_stock()) {
+      if ($show_low_stock_amount && $product->get_stock_quantity() > 0 && $product->get_stock_quantity() <= $low_stock_amount) {
         $stock['availability'] = sprintf(__('Only %s in stock', Plugin::L10N), $product->get_stock_quantity());
         $stock['class'] = 'low-stock';
       }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -129,6 +129,8 @@ class WooCommerce {
     $product->set_backorders('yes');
 
     // If low stock threshold is not set at product level, get global option.
+    // Zero is allowed so just check for empty string as in WooCommerce Core.
+    // @see https://git.io/Je7ai
     if ($product->is_type('variation')) {
       $parent_product = wc_get_product($product->get_parent_id());
       $low_stock_amount = $parent_product->get_low_stock_amount();
@@ -136,7 +138,7 @@ class WooCommerce {
     else {
       $low_stock_amount = $product->get_low_stock_amount();
     }
-    if (empty($low_stock_amount)) {
+    if ($low_stock_amount === '') {
       $low_stock_amount = get_option('woocommerce_notify_low_stock_amount');
     }
 

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -142,8 +142,8 @@ class WooCommerce {
         $stock['availability'] = __('Out of stock', 'woocommerce');
         $stock['class'] = 'out-of-stock';
       }
-      elseif ($product->get_stock_quantity() <= $low_stock_amount) {
-        $stock['availability'] = sprintf(__('Only %s in stock', Plugin::L10N), $low_stock_amount);
+      elseif ($product->get_stock_quantity() > 0 && $product->get_stock_quantity() <= $low_stock_amount) {
+        $stock['availability'] = sprintf(__('Only %s in stock', Plugin::L10N), $product->get_stock_quantity());
         $stock['class'] = 'low-stock';
       }
       else {


### PR DESCRIPTION
### Ticket
- [Show low stock levels in frontend](https://app.asana.com/0/30156186242982/1133642108266488/f)

### Description
- Products can be ordered even if stock level is zero.
- Previously, "only 0 in stock" was shown in this scenario.
