### PR TITLE
Fixed sale percentage was not updated for bundle products.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.30.8",
+  "version": "1.30.9",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.30.8
+  Version: 1.30.9
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -98,7 +98,7 @@ class Admin {
         $parent_id = $product->get_parent_id();
         static::saveSalePercentage($parent_id, get_post($parent_id));
       }
-      else {
+      elseif ($product->get_type() === 'simple' || $product->get_type() === 'bundle') {
         static::saveSalePercentage($object_id, get_post($object_id));
       }
     }

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -98,7 +98,7 @@ class Admin {
         $parent_id = $product->get_parent_id();
         static::saveSalePercentage($parent_id, get_post($parent_id));
       }
-      elseif ($product->get_type() === 'simple') {
+      else {
         static::saveSalePercentage($object_id, get_post($object_id));
       }
     }


### PR DESCRIPTION
### Ticket
- [Sale Bubble shows wrong value "-0 %" / NUTR & LOFI](1154739415381321)

### Description
-
