### PR TITLE
Fixed PHP notice when trying to defer enqueuing of scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.30.13",
+  "version": "1.30.14",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.30.13
+  Version: 1.30.14
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Performance.php
+++ b/src/Performance.php
@@ -86,7 +86,7 @@ class Performance {
     global $wp_scripts;
 
     foreach ($wp_scripts->queue as $handle) {
-      $script = $wp_scripts->registered[$handle];
+      $script = $wp_scripts->registered[$handle] ?? [];
       // Weird way to check if script is being enqueued in the footer.
       if (!isset($script->extra['group']) || $script->extra['group'] !== 1) {
         continue;


### PR DESCRIPTION
### Description
- A PHP Notice is displayed when trying to defer the enqueueing of scripts:
> Notice: Undefined index: select2 in /Users/joan/Sites/netzstrategen/nutr/nutr/htdocs/wp-content/plugins/shop-standards/src/Performance.php on line 89
