### PR TITLE
Fixed PHP notice in delivery time filter widget.

### DIFF
--- a/src/ProductFilters/WidgetFilterDeliveryTime.php
+++ b/src/ProductFilters/WidgetFilterDeliveryTime.php
@@ -77,7 +77,7 @@ class WidgetFilterDeliveryTime extends \WC_Widget {
 
     echo '<ul class="product_delivery_time_widget">';
     foreach ($delivery_times as $delivery_time) {
-      if (!$instance['delivery_time-' . $delivery_time->term_id]) {
+      if (empty($instance['delivery_time-' . $delivery_time->term_id])) {
         continue;
       }
       $values = $filter_values;


### PR DESCRIPTION
### Description
- A PHP notice was thrown in filter by delivery time widget if delivery time tem id is not defined.

```
Notice: Undefined index: delivery_time-9641 in /Users/joan/Sites/netzstrategen/gaco/htdocs/wp-content/plugins/shop-standards/src/ProductFilters/WidgetFilterDeliveryTime.php on line 80
```
