### PR TITLE
Fixed PHP notice caused by missing method in class WooCommerce.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.30.19",
+  "version": "1.30.20",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.30.19
+  Version: 1.30.20
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -28,11 +28,6 @@ class Admin {
     // Adds products variations custom fields.
     add_action('woocommerce_product_after_variable_attributes', __NAMESPACE__ . '\WooCommerce::woocommerce_product_after_variable_attributes', 10, 3);
 
-    // Assigns sale category conditionally on product update.
-    if (get_option('_' . Plugin::L10N . '_enable_auto_sale_category_assignment') === 'yes') {
-      add_action('woocommerce_update_product', __NAMESPACE__ . '\WooCommerce::woocommerce_update_product');
-    }
-
     // Allow ajax requests to specified functions.
     add_action('wp_ajax_is_existing_gtin', __NAMESPACE__ . '\WooCommerce::wp_ajax_is_existing_gtin');
 


### PR DESCRIPTION
### Description
- Reported by @sun on Slack: https://netzstrategen.slack.com/archives/CAMP1MQJ2/p1586187404017700
- Caused by previous refactoring: https://github.com/netzstrategen/wordpress-shop-standards/commit/71654ed0a9da1c1f0198e13e6a7f1ce18acb0397
