### PR TITLE
Fixed Plus Products error message was shown if the cart was empty.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.32.0",
+  "version": "1.32.1",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.32.0
+  Version: 1.32.1
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/PlusProducts.php
+++ b/src/PlusProducts.php
@@ -49,8 +49,10 @@ class PlusProducts {
    * @implements woocommerce_check_cart_items
    */
   public static function displayPlusProductsNotice() {
+    if (WC()->cart->is_empty()) {
+      return;
+    }
     $plusCategory = get_term_by('id', get_option('_' . Plugin::L10N . '_plus_products_category'), 'product_cat');
-
     if (is_wp_error($plusCategory) || empty($plusCategory)) {
       return;
     }


### PR DESCRIPTION
### Ticket
- [Fix Plus Product warning message is displayed on empty carts](https://app.asana.com/0/106767930274882/1175093376311869)