### PR TITLE
Fixed wrong non-euro schema.org prices on single product template.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.33.0",
+  "version": "1.33.1",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.33.0
+  Version: 1.33.1
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -181,6 +181,8 @@ class Plugin {
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductGtin');
     // Adds Brand name to schema.org.
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductBrand');
+    // Adds correct price in schema.org.
+    add_filter('woocommerce_structured_data_product_offer', __NAMESPACE__ . '\Seo::adjustPrice', 10, 2);
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -181,7 +181,7 @@ class Plugin {
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductGtin');
     // Adds Brand name to schema.org.
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductBrand');
-    // Changes schema.org prices according to tax settings.
+    // Fixes schema.org prices according to tax settings.
     add_filter('woocommerce_structured_data_product_offer', __NAMESPACE__ . '\Seo::adjustPrice', 10, 2);
   }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -181,7 +181,7 @@ class Plugin {
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductGtin');
     // Adds Brand name to schema.org.
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductBrand');
-    // Adds correct price in schema.org.
+    // Changes schema.org prices according to tax settings.
     add_filter('woocommerce_structured_data_product_offer', __NAMESPACE__ . '\Seo::adjustPrice', 10, 2);
   }
 

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -166,4 +166,22 @@ class Seo {
     return $data;
   }
 
+  /**
+   * Ensures the prices is the correct one, according to tax setings.
+   *
+   * @implements woocommerce_structured_data_product_offer
+   */
+  public static function adjustPrice($markup, $product) {
+    if (wc_prices_include_tax()) {
+      $product_price = wc_get_price_including_tax($product);
+    }
+    else {
+      $product_price = wc_get_price_excluding_tax($product);
+    }
+    $markup['price'] = $product_price;
+    $markup['priceSpecification']['price'] = $product_price;
+
+    return $markup;
+  }
+
 }

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -167,7 +167,7 @@ class Seo {
   }
 
   /**
-   * Ensures the prices is the correct one, according to tax setings.
+   * Changes schema.org prices according to tax settings.
    *
    * @implements woocommerce_structured_data_product_offer
    */

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -171,9 +171,9 @@ class Seo {
    *
    * When retrieving product prices to add into schema.org woocommerce is not
    * considering if they already includes taxes, as set in the backend. This
-   * seems to be caused by aelya-currency-switcher currency conversion.
+   * seems to be caused by aelia-currency-switcher currency conversion.
    *
-   * See https://github.com/woocommerce/woocommerce/blob/bfac625cdcda4d7d14e85ca3cf5534e86081e7bc/includes/class-wc-structured-data.php#L222-L223
+   * See https://bit.ly/2ZLZxIs
    *
    * @implements woocommerce_structured_data_product_offer
    */
@@ -185,7 +185,7 @@ class Seo {
     $prices_include_tax = wc_prices_include_tax();
 
     if ($product->get_type() === 'variable') {
-      $lowest  = $product->get_variation_price('min', $prices_include_tax);
+      $lowest = $product->get_variation_price('min', $prices_include_tax);
       $highest = $product->get_variation_price('max', $prices_include_tax);
       if ($lowest === $highest) {
         $markup['price'] = wc_format_decimal($lowest, wc_get_price_decimals());


### PR DESCRIPTION
### Ticket
- [Non-euro prices in the source code do not match the displayed prices](https://app.asana.com/0/809933051638353/1175777161118852/f)

### Description
-
