### PR TITLE
Fixed display of energy label from plugin wc-eu-energy-label could not be disabled by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.35.1",
+  "version": "1.35.2",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.35.1
+  Version: 1.35.2
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -24,6 +24,9 @@ class Admin {
     add_action('woocommerce_product_options_general_product_data', __NAMESPACE__ . '\WooCommerce::woocommerce_product_options_general_product_data');
     // Appends product notes custom field as the last field in the product general options section.
     add_action('woocommerce_product_options_general_product_data', __NAMESPACE__ . '\WooCommerce::productNotesCustomField', 999);
+    // Allows to force disabling the display of the product energy label added
+    // by plugin wc-eu-energy-label.
+    add_filter('get_post_metadata', __NAMESPACE__ . '\WooCommerce::get_post_metadata', 10, 4);
 
     // Adds products variations custom fields.
     add_action('woocommerce_product_after_variable_attributes', __NAMESPACE__ . '\WooCommerce::woocommerce_product_after_variable_attributes', 10, 3);

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -26,6 +26,25 @@ class WooCommerce {
       'type' => 'sectionend',
       'id' => Plugin::L10N,
     ];
+
+    // Allow to force disable the display of product energy label added by
+    // plugin wc-eu-energy-label.
+    if (class_exists('WC_Euenergylabel')) {
+      $settings[] = [
+        'type' => 'title',
+        'name' => __('Energy label settings', Plugin::L10N),
+      ];
+      $settings[] = [
+        'type' => 'checkbox',
+        'id' => '_' . Plugin::L10N . '_disable_energy_label',
+        'name' => __('Disable product energy label', Plugin::L10N),
+      ];
+      $settings[] = [
+        'type' => 'sectionend',
+        'id' => Plugin::L10N,
+      ];
+    }
+
     return $settings;
   }
 
@@ -268,6 +287,34 @@ class WooCommerce {
       'label' => __('Price comparison focus product', Plugin::L10N),
     ]);
     echo '</div>';
+  }
+
+  /**
+   * Allows to force disabling the display of the product energy label.
+   *
+   * The backend seting for shop-standards overrides the product setting
+   * toggling the display of the energy label added by plugin
+   * wc-eu-energy-label.
+   *
+   * @implements get_post_metadata
+   */
+  public static function get_post_metadata($value, $object_id, $meta_key, $single) {
+    if ($meta_key === 'wc_eu_energy_label_disable_frontend') {
+      global $wpdb;
+
+      $disableLabel = wc_string_to_bool($wpdb->get_var(
+        $wpdb->prepare(
+          "SELECT meta_value FROM $wpdb->postmeta
+          WHERE post_id = %s
+          AND meta_key = %s",
+          $object_id,
+          'wc_eu_energy_label_disable_frontend'
+        )
+      ));
+      $forceDisableLabel = wc_string_to_bool(get_option('_' . Plugin::L10N . '_disable_energy_label'));
+      $value = $disableLabel || $forceDisableLabel ? 'yes' : 'no';
+    }
+    return $value;
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [Add new checkbox in order to disable energy label displaying per default](https://app.asana.com/0/1156709897787098/1151258293585977)

### Description
-
