### PR TITLE
Fixed customer may be empty when using the WP CLI.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,6 +39,10 @@ class Plugin {
    * @implements init
    */
   public static function preInit() {
+    // Ensures a customer address is always set when using the WP CLI.
+    if (defined('WP_CLI') && WP_CLI) {
+      add_filter('pre_option_woocommerce_default_customer_address', function () { return 'base'; });
+    }
     // Enables revisions for product descriptions.
     // WooCommerce registers its post types very early in init with a priority
     // of 5, so we need to register upfront.


### PR DESCRIPTION
### Description
When using the WP CLI in combination with the customers base address to be `geolocation` the customer address will be empty causing not all hooks to work as expected.

In this specific case we wanted to generate product feeds but the tax calculation for some products failed as the base country could not be determined because it was set to geolocation which seems to not be available when using the CLI. As a fix we can set the customer to `base` which will use the base address of the shop instead.