### PR TITLE
Fixed strike price for variable products might not be displayed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.35.1",
+  "version": "1.35.2",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.35.1
+  Version: 1.35.2
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,10 +44,6 @@ class Plugin {
     // of 5, so we need to register upfront.
     add_filter('woocommerce_register_post_type_product', __NAMESPACE__ . '\WooCommerce::woocommerce_register_post_type_product');
 
-    // Adds strike price (range) labels for variable products, too.
-    add_filter('woocommerce_variable_sale_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_variable_sale_price_html', 10, 2);
-    add_filter('woocommerce_variable_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_variable_sale_price_html', 10, 2);
-
     add_action('parse_request', __CLASS__  . '::parse_request');
 
     // Allow to filter products by delivery time if woocommerce-german-market plugin is active.
@@ -85,6 +81,8 @@ class Plugin {
 
     // Displays sale price as regular price if custom field is checked.
     add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_price_html', 10, 2);
+    // Adds strike price (range) labels for variable products, too.
+    add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_variation_price_html', 10, 2);
 
     // Ensures new product are saved before updating its meta data.
     add_action('woocommerce_process_product_meta', __NAMESPACE__ . '\WooCommerce::saveNewProductBeforeMetaUpdate', 1);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -83,6 +83,8 @@ class Plugin {
     add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_price_html', 10, 2);
     // Adds strike price (range) labels for variable products, too.
     add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_variation_price_html', 10, 2);
+    // Remove "From" text prefixed to prices by B2B Market plugin (starting v1.0.6.1).
+    add_filter('bm_original_price_html', __NAMESPACE__ . '\WooCommerce::b2b_remove_prefix', 10, 2);
 
     // Ensures new product are saved before updating its meta data.
     add_action('woocommerce_process_product_meta', __NAMESPACE__ . '\WooCommerce::saveNewProductBeforeMetaUpdate', 1);

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -65,6 +65,16 @@ class WooCommerce {
   }
 
   /**
+   * Remove "From" text prefixed to prices by B2B Market plugin (starting v1.0.6.1).
+   *
+   * @implements bm_original_price_html
+   */
+  public static function b2b_remove_prefix($html, $product_id) {
+    $html = preg_replace('@<span class="b2b-price-prefix">.[^<]*</span>@', '', $html);
+    return $html;
+  }
+
+  /**
    * Enables revisions for product descriptions.
    *
    * @implements woocommerce_register_post_type_product

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -34,10 +34,12 @@ class WooCommerce {
    *
    * @see https://github.com/woocommerce/woocommerce/issues/16169
    *
-   * @implements woocommerce_variable_sale_price_html
-   * @implements woocommerce_variable_price_html
+   * @implements woocommerce_get_price_html
    */
-  public static function woocommerce_variable_sale_price_html($price, $product) {
+  public static function woocommerce_get_variation_price_html($price, $product) {
+    if ($product->get_type() !== 'variable') {
+      return $price;
+    }
     $sale_prices = [
       'min' => $product->get_variation_price('min', TRUE),
       'max' => $product->get_variation_price('max', TRUE),


### PR DESCRIPTION
### Description
- I couldn't find the history for the deprecation but given this answer, https://stackoverflow.com/a/46009513/2862127, `woocommerce_variable_sale_price_html` is deprecated since WC 3.0.
- I used another `woocommerce_get_price_html` hook as it seems some plugins are using this hook to override the output from the variable once again. Please see https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-product-variable.php#L167-L170
