### PR TITLE
Fixed loading header scripts twice due to preloading with wrong  query argument.

### DIFF
--- a/src/Performance.php
+++ b/src/Performance.php
@@ -128,7 +128,7 @@ class Performance {
       $version = '';
     }
     else {
-      $version = '?ver=' . ($handle->ver ? $handle->ver : Plugin::getGitVersion());
+      $version = '?ver=' . Plugin::getGitVersion();
     }
     $source = $handle->src . $version;
     return $source;

--- a/src/Performance.php
+++ b/src/Performance.php
@@ -128,7 +128,7 @@ class Performance {
       $version = '';
     }
     else {
-      $version = '?ver=' . ($handle->ver ? $handle->ver : Plugin::$version);
+      $version = '?ver=' . ($handle->ver ? $handle->ver : Plugin::getGitVersion());
     }
     $source = $handle->src . $version;
     return $source;


### PR DESCRIPTION
### Ticket
- [Assets on GACO are loaded twice](https://app.asana.com/0/809933051638353/1192191068119417)