### PR TITLE
Fixed WordPress admin UI is cluttered with messages notifying about new releases and more features.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -39,6 +39,9 @@ class Admin {
 
     // Removes woocommerce admin notices.
     add_filter('woocommerce_helper_suppress_admin_notices', '__return_true');
+
+    // Removes only woocommerce connect related admin notices.
+    add_filter('woocommerce_helper_suppress_connect_notice', '__return_true');
   }
 
   /**

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -37,10 +37,8 @@ class Admin {
     // Enqueues admin plugin scripts.
     add_action('admin_enqueue_scripts', __CLASS__ . '::admin_enqueue_scripts');
 
-    // Removes woocommerce admin notices.
+    // Removes admin notices about updating to version and connecting to WooCommerce.com.
     add_filter('woocommerce_helper_suppress_admin_notices', '__return_true');
-
-    // Removes only woocommerce connect related admin notices.
     add_filter('woocommerce_helper_suppress_connect_notice', '__return_true');
   }
 

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -36,6 +36,9 @@ class Admin {
 
     // Enqueues admin plugin scripts.
     add_action('admin_enqueue_scripts', __CLASS__ . '::admin_enqueue_scripts');
+
+    // Removes woocommerce admin notices.
+    add_filter('woocommerce_helper_suppress_admin_notices', '__return_true');
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [Remove WordPress release update and WooCommerce.com bragging notices](https://app.asana.com/0/354170587449545/1197780930151545/f)

### Description
-
