### PR TITLE
Fixed postcode validation was always false for LI and NL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.37.0",
+  "version": "1.37.1",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.37.0
+  Version: 1.37.1
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -905,9 +905,11 @@ class WooCommerce {
 
       case 'LI':
         $valid = (bool) preg_match('@^(948[5-9])|(949[0-7])$@', $postcode);
+        break;
 
       case 'NL':
         $valid = (bool) preg_match('@\d{4} ?[A-Z]{2}@', $postcode);
+        break;
     }
     return $valid;
   }


### PR DESCRIPTION
### Ticket
- [Valid four-digit Liechtenstein postcodes marked as invalid, stopping orders](https://app.asana.com/0/587433704548192/1199387326781845/f)
