### PR TITLE
Fixed instant search results show desynced sale bubbles.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.37.3",
+  "version": "1.37.4",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.37.3
+  Version: 1.37.4
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -58,6 +58,9 @@ class Plugin {
         add_action('pre_get_posts', __NAMESPACE__ . '\ProductFilters\DeliveryTime::pre_get_posts', 1);
       }
     }
+
+    // Hides sale percentage label.
+    add_filter('sale_percentage_output', __NAMESPACE__ . '\WooCommerce::sale_percentage_output', 10, 3);
   }
 
   /**
@@ -126,9 +129,6 @@ class Plugin {
 
     // Hides Add to Cart button for products that must not be sold online.
     add_filter('woocommerce_is_purchasable', __NAMESPACE__ . '\WooCommerce::is_purchasable', 10, 2);
-
-    // Hides sale percentage label.
-    add_filter('sale_percentage_output', __NAMESPACE__ . '\WooCommerce::sale_percentage_output', 10, 3);
 
     // Hides 'add to cart' button for products from specific categories or brands.
     add_action('wp_head', __NAMESPACE__ . '\WooCommerce::wp_head');


### PR DESCRIPTION
### Ticket
- [ES: instant search results show sale bubbles even when deactivated](https://app.asana.com/0/587433704548192/1191855237961641/f)

### Details
Percentage sale bubbles markup is indexed into ES, but `sale_percentage_output` was registered too late and not available for the ES index update.