### PR TITLE
Fixed back in stock date on product detail page not prominent enough.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.37.4",
+  "version": "1.37.5",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.37.4
+  Version: 1.37.5
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -179,7 +179,7 @@ class WooCommerce {
 
     if ($product->backorders_allowed() && $back_in_stock_date = get_post_meta($product->get_id(), '_shop-standards_back_in_stock_date', TRUE)) {
       if ($date_string = static::getBackInStockDateString($back_in_stock_date)) {
-        $stock['availability'] = sprintf(__('Back in stock %s', Plugin::L10N), $date_string);
+        $stock['availability'] = '<strong>' . sprintf(__('Back in stock %s', Plugin::L10N), $date_string) . '</strong>';
       }
     }
 
@@ -964,7 +964,7 @@ class WooCommerce {
     $product_id = $product->get_id();
 
     if ($back_in_stock_date = get_post_meta($product_id, '_' . Plugin::PREFIX . '_back_in_stock_date', TRUE)) {
-      $label_string .= ' ' . WooCommerce::getBackInStockDateString($back_in_stock_date);
+      $label_string .= ' <strong>' . WooCommerce::getBackInStockDateString($back_in_stock_date) . '</strong>';
     }
 
     return $label_string;


### PR DESCRIPTION
### Ticket
- ["Back in stock"-date/delivery time: optimization](https://app.asana.com/0/587433704548192/1199601303851103/f)