### PR TITLE
Fixed variations add to cart button not hidden when custom option set.

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -1,0 +1,5 @@
+// Ensure "Add To Cart" button and quantity field hidden when custom
+// checkbox (added in src/WooCommerce.php) is checked.
+.woocommerce-variation-add-to-cart-disabled {
+  display: none;
+}

--- a/dist/styles/main.min.css
+++ b/dist/styles/main.min.css
@@ -1,0 +1,1 @@
+.woocommerce-variation-add-to-cart-disabled{display:none}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.38.0",
+  "version": "1.38.1",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.38.0
+  Version: 1.38.1
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -288,6 +288,7 @@ class Plugin {
   public static function wp_enqueue_scripts() {
     $git_version = static::getGitVersion();
 
+    wp_enqueue_style(Plugin::PREFIX, static::getBaseUrl() . '/dist/styles/main.min.css', FALSE, $git_version);
     wp_enqueue_script(Plugin::PREFIX, static::getBaseUrl() . '/dist/scripts/main.min.js', ['jquery'], $git_version, TRUE);
     wp_localize_script(Plugin::PREFIX, 'shop_standards_settings', [
       'emailConfirmationEmail' => get_option('_' . Plugin::L10N . '_checkout_email_confirmation_field'),


### PR DESCRIPTION
### Ticket
- ["hide add to cart button" checkbox not working for variable products](https://app.asana.com/0/30156186242982/1200029023488134/f)

### Description
- Custom "Hide add to cart button" (added [here](https://github.com/netzstrategen/wordpress-shop-standards/commit/690d6c870911f709be1ffb65456d0fc2ed21cfad)) works for single products but not variations
- Button+quantity section is changed via JS so not feasible to remove completely via PHP
- 'disabled' class added to button is used in JS to prevent purchases so CSS-only hide here is ok
