### PR TITLE
Fixed incorrect product availability schema.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.38.1",
+  "version": "1.38.2",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.38.1
+  Version: 1.38.2
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -254,10 +254,10 @@ class Seo {
   public static function adjustAvailability($markup, $product) {
     if ($product->get_type() === 'variable') {
       $in_stock = (bool) count(array_filter($product->get_available_variations('object'), function ($variant) {
-        return $variant->get_stock_quantity() || $variant->backorders_allowed();
+        return ($variant->get_stock_quantity() > 0) || $variant->backorders_allowed();
       }));
     }
-    if ($product->get_stock_quantity() || $product->backorders_allowed() || !empty($in_stock)) {
+    if (($product->get_stock_quantity() > 0) || $product->backorders_allowed() || !empty($in_stock)) {
       $markup['availability'] = 'https://schema.org/InStock';
     }
     return $markup;

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -254,7 +254,7 @@ class Seo {
   public static function adjustAvailability($markup, $product) {
     if ($product->get_type() === 'variable') {
       $in_stock = (bool) count(array_filter($product->get_available_variations('object'), function ($variant) {
-        return $variant->is_in_stock();
+        return $variant->get_stock_quantity() || $variant->backorders_allowed();
       }));
     }
     if ($product->get_stock_quantity() || $product->backorders_allowed() || !empty($in_stock)) {

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -252,7 +252,12 @@ class Seo {
    * @implements woocommerce_structured_data_product_offer
    */
   public static function adjustAvailability($markup, $product) {
-    if ($product->get_stock_quantity() || $product->backorders_allowed()) {
+    if ($product->get_type() === 'variable') {
+      $in_stock = (bool) count(array_filter($product->get_available_variations('object'), function ($variant) {
+        return $variant->is_in_stock();
+      }));
+    }
+    if ($product->get_stock_quantity() || $product->backorders_allowed() || !empty($in_stock)) {
       $markup['availability'] = 'https://schema.org/InStock';
     }
     return $markup;


### PR DESCRIPTION
### Description
- A product should be shown as available if any of a variant is in stock regardless of the parent product.
