### PR TITLE
Fixed first page link in pagination causes redirect to actual initial listing page.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -209,7 +209,7 @@ class Plugin {
      */
     add_filter('paginate_links', function ($link) {
       $link = preg_replace('@/page/1/?(\?|$)@', '$1', $link);
-      return $link;
+      return user_trailingslashit($link);
     });
   }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -203,6 +203,14 @@ class Plugin {
 
     // Disables output of related products if over-ride checkbox is enabled.
     add_action('woocommerce_after_single_product_summary', __NAMESPACE__ . '\WooCommerce::disableRelatedProducts', 0, 2);
+
+    /**
+     * Removes the `/page/1` suffix from archive URLs.
+     */
+    add_filter('paginate_links', function ($link) {
+      $link = preg_replace('@/page/1/?(\?|$)@', '$1', $link);
+      return $link;
+    });
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -204,13 +204,8 @@ class Plugin {
     // Disables output of related products if over-ride checkbox is enabled.
     add_action('woocommerce_after_single_product_summary', __NAMESPACE__ . '\WooCommerce::disableRelatedProducts', 0, 2);
 
-    /**
-     * Removes the `/page/1` suffix from archive URLs.
-     */
-    add_filter('paginate_links', function ($link) {
-      $link = preg_replace('@/page/1/?(\?|$)@', '$1', $link);
-      return user_trailingslashit($link);
-    });
+    // Removes the `/page/1` suffix from archive URLs.
+    add_filter('paginate_links', __CLASS__  . '::paginate_links');
   }
 
   /**
@@ -352,6 +347,16 @@ class Plugin {
    */
   public static function loadTextdomain() {
     load_plugin_textdomain(static::L10N, FALSE, static::L10N . '/languages/');
+  }
+
+  /**
+   * Removes the `/page/1` suffix from archive URLs.
+   *
+   * @return string
+   */
+  public static function paginate_links($link) {
+    $link = preg_replace('@/page/1/?(\?|$)@', '$1', $link);
+    return user_trailingslashit($link);
   }
 
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -204,7 +204,7 @@ class Plugin {
     // Disables output of related products if over-ride checkbox is enabled.
     add_action('woocommerce_after_single_product_summary', __NAMESPACE__ . '\WooCommerce::disableRelatedProducts', 0, 2);
 
-    // Removes the `/page/1` suffix from archive URLs.
+    // Removes the suffix '/page/1' from archive URLs.
     add_filter('paginate_links', __CLASS__  . '::paginate_links');
   }
 
@@ -350,7 +350,7 @@ class Plugin {
   }
 
   /**
-   * Removes the `/page/1` suffix from archive URLs.
+   * Removes the suffix '/page/1' from archive URLs.
    *
    * @return string
    */

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1200,4 +1200,12 @@ class WooCommerce {
     }
   }
 
+  /**
+   * Removes the `/page/1` suffix from archive URLs.
+   */
+  add_filter('paginate_links', function ($link) {
+    $link = preg_replace('@/page/1/?(\?|$)@', '$1', $link);
+    return $link;
+  });
+
 }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1200,12 +1200,4 @@ class WooCommerce {
     }
   }
 
-  /**
-   * Removes the `/page/1` suffix from archive URLs.
-   */
-  add_filter('paginate_links', function ($link) {
-    $link = preg_replace('@/page/1/?(\?|$)@', '$1', $link);
-    return $link;
-  });
-
 }


### PR DESCRIPTION
### Ticket
- [Prevent pagination links to page 1 that contain the page suffix. ](https://app.asana.com/0/507013885678070/1200321868255267/f)

### Description
-
