### PR TITLE
Fixed back-in-stock not showing for variable products in products listing.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -994,17 +994,18 @@ class WooCommerce {
    *    The earliest back in stock date, if any.
    */
   public static function getEarliestBackInStock($product) {
-    if (!$product->get_stock_quantity()) {
+    if ($product->get_stock_quantity() > 0) {
       return '';
     }
 
     $meta_key = '_' . Plugin::PREFIX . '_back_in_stock_date';
-    $back_in_stock_date = get_post_meta($product->get_id(), $meta_key, TRUE);
+    $back_in_stock_date = get_post_meta($product->get_id(), $meta_key, TRUE) ?? '';
 
     if ($product->is_type('variable')) {
       $variations = $product->get_available_variations();
       foreach ($variations as $variation) {
-        if ($variation['max_qty'] > 0) {
+        $variation_obj = wc_get_product($variation['variation_id']);
+        if ($variation_obj->get_stock_quantity()> 0) {
           return '';
         }
         $variation_stock_date = get_post_meta($variation['variation_id'], $meta_key, TRUE);

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1019,7 +1019,8 @@ class WooCommerce {
       }
     }
 
-    return $back_in_stock_date;
+    // Returns the date only if it's in the future.
+    return $back_in_stock_date > time() ? $back_in_stock_date : '';
   }
 
   /**

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -988,12 +988,14 @@ class WooCommerce {
   /**
    * Retrieves the earliest "back in stock" date from a product or its variations.
    * If there's stock, the product is considered available and nothing is returned.
+   *
    * @param WC_Product
    *    The product object.
+   *
    * @return string
    *    The earliest back in stock date, if any.
    */
-  public static function getEarliestBackInStock($product) {
+  public static function getEarliestBackInStock(\WC_Product $product): string {
     if ($product->get_stock_quantity() > 0) {
       return '';
     }
@@ -1004,11 +1006,11 @@ class WooCommerce {
     if ($product->is_type('variable')) {
       $variations = $product->get_available_variations();
       foreach ($variations as $variation) {
-        $variation_obj = wc_get_product($variation['variation_id']);
+        $product_variation = wc_get_product($variation['variation_id']);
         $variation_stock_date = get_post_meta($variation['variation_id'], $meta_key, TRUE);
         // If a variation has stock or doesn't have a "back in stock" date
         // it's considered to be immediately available for purchase.
-        if ($variation_obj->get_stock_quantity() > 0 || !$variation_stock_date) {
+        if ($product_variation->get_stock_quantity() > 0 || !$variation_stock_date) {
           return '';
         }
         if (!$back_in_stock_date || $back_in_stock_date > $variation_stock_date) {

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1005,10 +1005,12 @@ class WooCommerce {
       $variations = $product->get_available_variations();
       foreach ($variations as $variation) {
         $variation_obj = wc_get_product($variation['variation_id']);
-        if ($variation_obj->get_stock_quantity()> 0) {
+        $variation_stock_date = get_post_meta($variation['variation_id'], $meta_key, TRUE);
+        // If a variation has stock or doesn't have a "back in stock" date
+        // it's considered to be immediately available for purchase.
+        if ($variation_obj->get_stock_quantity() > 0 || !$variation_stock_date) {
           return '';
         }
-        $variation_stock_date = get_post_meta($variation['variation_id'], $meta_key, TRUE);
         if (!$back_in_stock_date || $back_in_stock_date > $variation_stock_date) {
           $back_in_stock_date = $variation_stock_date;
         }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1020,7 +1020,7 @@ class WooCommerce {
     }
 
     // Returns the date only if it's in the future.
-    return $back_in_stock_date > time() ? $back_in_stock_date : '';
+    return strtotime($back_in_stock_date) > time() ? $back_in_stock_date : '';
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [Variable Products: missing "back in stock"-date (overview pages)](https://app.asana.com/0/809933051638353/1200306165872411)

### Description
The "back in stock" date was visible for "simple products" only. The reason is that the logic was only getting the date from the "master product", which only works for "simple products" since such date is stored on each product variation. This PR extends the current logic by gathering the "EarliestBackInStock" date either from the master product (in the case of simple products) or from variations (in the case of variable products).