### PR TITLE
Fixes trailing slash issue on pagination.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -355,8 +355,7 @@ class Plugin {
    * @return string
    */
   public static function paginate_links($link) {
-    $link = preg_replace('@/page/1/?(\?|$)@', '$1', $link);
-    return user_trailingslashit($link);
+    return preg_replace('@page/1/?(\?|$)@', '$1', $link);
   }
 
 }


### PR DESCRIPTION
### Ticket
- [Prevent pagination links to page 1 that contain the page suffix. ](https://app.asana.com/0/0/1200322193267937/f)

### Description
- slash before /page in regex is not needed.
