### PR TITLE
Fixed delivery time in order confirmation use value at order time

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -784,15 +784,13 @@ class WooCommerce {
     }
     $product_data_set = array_merge($data, static::getProductAttributes($product));
 
-    // Display delivery time from woocommerce-german-market for each order item.
-    if (method_exists('WGM_Template', 'get_deliverytime_string')) {
-      $delivery_time = \WGM_Template::get_deliverytime_string($product);
-    }
-    else {
-      $delivery_time = wc_get_order_item_meta($item->get_id(), '_deliverytime');
-      $delivery_time = get_term($delivery_time, 'product_delivery_times');
-      $delivery_time = $delivery_time->name ?? '';
-    }
+    // Display delivery time from order item meta for each order item.
+    $delivery_time = wc_get_order_item_meta($item->get_id(), '_deliverytime');
+    $delivery_time = get_term($delivery_time, 'product_delivery_times');
+    $delivery_time = $delivery_time->name ?? '';
+    // Add the back in stock date next to the delivery time.
+    $delivery_time = self::woocommerce_de_get_deliverytime_string_label_string($delivery_time, $product);
+
     if ($delivery_time) {
       array_splice($product_data_set, 1, 0, [[
         'name' => __('Delivery Time', 'woocommerce-german-market'),


### PR DESCRIPTION
### Ticket
- [Customer account: Change/delete delivery time in order confirmation](https://app.asana.com/0/30156186242982/1200426661151439/f)

### Description
-Changes have been made to staging to show the delivery time in the order confirmation as it was specified at the moment of the order. This instead of using the current product delivery time property
