### PR TITLE
Fixed PHP warning on settings page if there are no product categories yet.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -974,15 +974,10 @@ class WooCommerce {
   public static function getTaxonomyTermsAsSelectOptions($taxonomy) {
     $terms = get_terms([
       'taxonomy' => $taxonomy,
+      'fields' => 'id=>name',
       'hide_empty' => false,
     ]);
-
-    $term_options = array_reduce($terms, function($result, $term) {
-      $result[$term->term_id] = $term->name;
-      return $result;
-    });
-
-    return is_wp_error($terms) ? [] : $term_options;
+    return is_wp_error($terms) ? [] : $terms;
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [PHP warning  on shop-standards page](https://app.asana.com/0/809933051638353/1200676005221602/f)

### Description
- The code does not use the API correctly and attempts to operate on an empty/error result.
