### PR TITLE
Added cronjob to remove outdated back-in-stock metadata for products without Moeve ID.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.40.5",
+  "version": "1.40.6",
   "title": "shop-standards",
   "description": "Standard refinements for e-commerce websites.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Standards
-  Version: 1.40.5
+  Version: 1.40.6
   Text Domain: shop-standards
   Description: Standard refinements for e-commerce websites.
   Author: netzstrategen

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -38,7 +38,7 @@ class Plugin {
    *
    * @var string
    */
-  const CRON_EVENT_ENSURE_BACK_IN_STOCK = Plugin::PREFIX . '/cron/ensure-back-in-stock';
+  const CRON_EVENT_ENSURE_BACK_IN_STOCK = Plugin::PREFIX . '/remove-past-back-in-stock';
 
   /**
    * Plugin initialization method with the lowest possible priority.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -182,6 +182,11 @@ class Plugin {
       add_filter('woocommerce_de_avoid_check_same_delivery_time_show_parent', '__return_true');
     }
 
+    add_action(self::CRON_EVENT_ENSURE_BACK_IN_STOCK, __NAMESPACE__ . '\WooCommerce::cron_ensure_back_in_stock');
+    if (!wp_next_scheduled(static::CRON_EVENT_ENSURE_BACK_IN_STOCK)) {
+      wp_schedule_event(strtotime('3am tomorrow'), 'daily', self::CRON_EVENT_ENSURE_BACK_IN_STOCK);
+    }
+
     // Prefetches DNS entries for particular resources.
     add_filter('wp_resource_hints', __NAMESPACE__ . '\Performance::wp_resource_hints', 10, 2);
     // Preloads scripts and loads styles asynchronously.
@@ -217,11 +222,6 @@ class Plugin {
 
     // Override page title on product attribute pages.
     add_filter('woocommerce_page_title', __NAMESPACE__ . '\ProductAttributePageTitle::woocommerce_page_title');
-
-    add_action(self::CRON_EVENT_ENSURE_BACK_IN_STOCK, __NAMESPACE__ . '\Schema::cron_ensure_back_in_stock');
-    if (!wp_next_scheduled(static::CRON_EVENT_ENSURE_BACK_IN_STOCK)) {
-      wp_schedule_event(strtotime('3am tomorrow'), 'daily', self::CRON_EVENT_ENSURE_BACK_IN_STOCK);
-    }
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,6 +34,13 @@ class Plugin {
   public static $version = '';
 
   /**
+   * Cron event name for checking database indexes.
+   *
+   * @var string
+   */
+  const CRON_EVENT_ENSURE_BACK_IN_STOCK = Plugin::PREFIX . '/cron/ensure-back-in-stock';
+
+  /**
    * Plugin initialization method with the lowest possible priority.
    *
    * @implements init
@@ -210,6 +217,11 @@ class Plugin {
 
     // Override page title on product attribute pages.
     add_filter('woocommerce_page_title', __NAMESPACE__ . '\ProductAttributePageTitle::woocommerce_page_title');
+
+    add_action(self::CRON_EVENT_ENSURE_BACK_IN_STOCK, __NAMESPACE__ . '\Schema::cron_ensure_back_in_stock');
+    if (!wp_next_scheduled(static::CRON_EVENT_ENSURE_BACK_IN_STOCK)) {
+      wp_schedule_event(strtotime('3am tomorrow'), 'daily', self::CRON_EVENT_ENSURE_BACK_IN_STOCK);
+    }
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -38,7 +38,7 @@ class Plugin {
    *
    * @var string
    */
-  const CRON_EVENT_ENSURE_BACK_IN_STOCK = Plugin::PREFIX . '/remove-past-back-in-stock';
+  const CRON_EVENT_REMOVE_BACK_IN_STOCK = Plugin::PREFIX . '/remove-past-back-in-stock';
 
   /**
    * Plugin initialization method with the lowest possible priority.
@@ -182,9 +182,11 @@ class Plugin {
       add_filter('woocommerce_de_avoid_check_same_delivery_time_show_parent', '__return_true');
     }
 
-    add_action(self::CRON_EVENT_ENSURE_BACK_IN_STOCK, __NAMESPACE__ . '\WooCommerce::cron_ensure_back_in_stock');
-    if (!wp_next_scheduled(static::CRON_EVENT_ENSURE_BACK_IN_STOCK)) {
-      wp_schedule_event(strtotime('3am tomorrow'), 'daily', self::CRON_EVENT_ENSURE_BACK_IN_STOCK);
+    if (function_exists('wc_get_product')) {
+      add_action(self::CRON_EVENT_REMOVE_BACK_IN_STOCK, __NAMESPACE__ . '\WooCommerce::cron_remove_back_in_stock');
+      if (!wp_next_scheduled(static::CRON_EVENT_REMOVE_BACK_IN_STOCK)) {
+        wp_schedule_event(strtotime('03:00:00'), 'daily', self::CRON_EVENT_REMOVE_BACK_IN_STOCK);
+      }
     }
 
     // Prefetches DNS entries for particular resources.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,7 +34,7 @@ class Plugin {
   public static $version = '';
 
   /**
-   * Cron event name for checking database indexes.
+   * Cron event name for removing outdated back-in-stock product metadata.
    *
    * @var string
    */

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -26,7 +26,7 @@ class Schema {
   }
 
   /**
-   * Cron event callback to ensure proper database indexes.
+   * Cron event callback to remove outdated back-in-stock product metadata.
    */
   public static function cron_ensure_back_in_stock() {
     global $wpdb;
@@ -34,7 +34,7 @@ class Schema {
       INNER JOIN {$wpdb->postmeta} pm ON {$wpdb->posts}.ID = pm.post_id
       LEFT JOIN {$wpdb->postmeta} moeve ON {$wpdb->posts}.ID = moeve.post_id AND moeve.meta_key LIKE %s
       WHERE pm.meta_key = %s
-        AND pm.meta_value <= CURRENT_DATE()
+        AND pm.meta_value <= %s
         AND moeve.meta_id IS NULL", [
           '_woocommerce-moeve_id_%',
           '_' . Plugin::PREFIX . '_back_in_stock_date',

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -42,6 +42,10 @@ class Schema {
 
     foreach ($ids as $id) {
       delete_post_meta($id, '_' . Plugin::PREFIX . '_back_in_stock_date');
+      if (function_exists('wc_get_product')) {
+        $product = wc_get_product($product);
+        $product->save();
+      }
     }
   }
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -25,28 +25,4 @@ class Schema {
   public static function uninstall() {
   }
 
-  /**
-   * Cron event callback to remove outdated back-in-stock product metadata.
-   */
-  public static function cron_ensure_back_in_stock() {
-    global $wpdb;
-    $ids = $wpdb->get_col($wpdb->prepare("SELECT ID FROM {$wpdb->posts}
-      INNER JOIN {$wpdb->postmeta} pm ON {$wpdb->posts}.ID = pm.post_id
-      LEFT JOIN {$wpdb->postmeta} moeve ON {$wpdb->posts}.ID = moeve.post_id AND moeve.meta_key LIKE %s
-      WHERE pm.meta_key = %s
-        AND pm.meta_value <= %s
-        AND moeve.meta_id IS NULL", [
-          '_woocommerce-moeve_id_%',
-          '_' . Plugin::PREFIX . '_back_in_stock_date',
-    ]));
-
-    foreach ($ids as $id) {
-      delete_post_meta($id, '_' . Plugin::PREFIX . '_back_in_stock_date');
-      if (function_exists('wc_get_product')) {
-        $product = wc_get_product($product);
-        $product->save();
-      }
-    }
-  }
-
 }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -25,4 +25,24 @@ class Schema {
   public static function uninstall() {
   }
 
+  /**
+   * Cron event callback to ensure proper database indexes.
+   */
+  public static function cron_ensure_back_in_stock() {
+    global $wpdb;
+    $ids = $wpdb->get_col($wpdb->prepare("SELECT ID FROM {$wpdb->posts}
+      INNER JOIN {$wpdb->postmeta} pm ON {$wpdb->posts}.ID = pm.post_id
+      LEFT JOIN {$wpdb->postmeta} moeve ON {$wpdb->posts}.ID = moeve.post_id AND moeve.meta_key LIKE %s
+      WHERE pm.meta_key = %s
+        AND pm.meta_value <= CURRENT_DATE()
+        AND moeve.meta_id IS NULL", [
+          '_woocommerce-moeve_id_%',
+          '_' . Plugin::PREFIX . '_back_in_stock_date',
+    ]));
+
+    foreach ($ids as $id) {
+      delete_post_meta($id, '_' . Plugin::PREFIX . '_back_in_stock_date');
+    }
+  }
+
 }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -191,18 +191,18 @@ class WooCommerce {
    */
   public static function cron_ensure_back_in_stock() {
     global $wpdb;
-    $ids = $wpdb->get_col($wpdb->prepare("SELECT ID FROM {$wpdb->posts}
-      INNER JOIN {$wpdb->postmeta} pm ON {$wpdb->posts}.ID = pm.post_id
-      LEFT JOIN {$wpdb->postmeta} moeve ON {$wpdb->posts}.ID = moeve.post_id AND moeve.meta_key LIKE %s
-      WHERE pm.meta_key = %s
-        AND pm.meta_value <= %s
+    $ids = $wpdb->get_col($wpdb->prepare("SELECT p.ID FROM {$wpdb->posts} p
+      INNER JOIN {$wpdb->postmeta} backinstock ON p.ID = backinstock.post_id
+      LEFT JOIN {$wpdb->postmeta} moeve ON p.ID = moeve.post_id AND moeve.meta_key LIKE %s
+      WHERE backinstock.meta_key = %s
+        AND backinstock.meta_value <= %s
         AND moeve.meta_id IS NULL", [
           '_woocommerce-moeve_id_%',
           '_' . Plugin::PREFIX . '_back_in_stock_date',
-          date('Y-m-d H:i:s'),
+          date('Y-m-d'),
     ]));
     foreach ($ids as $id) {
-      if (function_exists('wc_get_product') && $product = wc_get_product($id)) {
+      if ($product = wc_get_product($id)) {
         $product->delete_meta_data('_' . Plugin::PREFIX . '_back_in_stock_date');
         $product->save();
       }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -189,7 +189,7 @@ class WooCommerce {
   /**
    * Cron event callback to remove outdated back-in-stock product metadata.
    */
-  public static function cron_ensure_back_in_stock() {
+  public static function cron_remove_back_in_stock() {
     global $wpdb;
     $ids = $wpdb->get_col($wpdb->prepare("SELECT p.ID FROM {$wpdb->posts} p
       INNER JOIN {$wpdb->postmeta} backinstock ON p.ID = backinstock.post_id


### PR DESCRIPTION
### Ticket
- [shop-standards: Obsolete back in stock dates are not removed from database](https://app.asana.com/0/30156186242982/1200496606141091/f)