### PR TITLE
Fixed performance bottleneck caused by earliest back in stock functionality.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -188,7 +188,7 @@ class WooCommerce {
     }
 
     if ($product->backorders_allowed() && $back_in_stock_date = self::getEarliestBackInStock($product)) {
-      $date_string = static::getFormatBackInStockDateString($back_in_stock_date);
+      $date_string = static::getFormattedBackInStockDateString($back_in_stock_date);
       $stock['availability'] = '<strong>' . sprintf(__('Back in stock %s', Plugin::L10N), $date_string) . '</strong>';
     }
 
@@ -1036,10 +1036,10 @@ class WooCommerce {
     }
 
     if ($product->is_type('variable')) {
-      $variations = $product->get_available_variations();
+      $variations = $product->get_children();
       foreach ($variations as $variation) {
-        $product_variation = wc_get_product($variation['variation_id']);
-        $variation_stock_date = get_post_meta($variation['variation_id'], self::FIELD_BACK_IN_STOCK_DATE, TRUE);
+        $product_variation = wc_get_product($variation);
+        $variation_stock_date = get_post_meta($variation, self::FIELD_BACK_IN_STOCK_DATE, TRUE);
         // If a variation has stock or doesn't have a "back in stock" date
         // it's considered to be immediately available for purchase.
         if ($product_variation->get_stock_quantity() > 0 || !$variation_stock_date) {
@@ -1068,7 +1068,7 @@ class WooCommerce {
     }
 
     if ($back_in_stock_date = self::getEarliestBackInStock($product)) {
-      $label_string .= ' <strong>' . WooCommerce::getFormatBackInStockDateString($back_in_stock_date) . '</strong>';
+      $label_string .= ' <strong>' . WooCommerce::getFormattedBackInStockDateString($back_in_stock_date) . '</strong>';
     }
 
     return $label_string;
@@ -1129,7 +1129,7 @@ class WooCommerce {
    *
    * The given input date must be already validated as in the future
    */
-  public static function getFormatBackInStockDateString($date_string): string {
+  public static function getFormattedBackInStockDateString($date_string): string {
     // translators: from date, e.g. available 'from 24.10.2019'
     return sprintf(__('from %1$s', Plugin::L10N), date_i18n('d.m.Y', strtotime($date_string)));
   }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1063,7 +1063,9 @@ class WooCommerce {
    * @implements woocommerce_de_get_deliverytime_string_label_string
    */
   public static function woocommerce_de_get_deliverytime_string_label_string($label_string, $product) {
-    if (!$product) {
+    // Avoid the execution of this function for product variants which can be
+    // evaluated over the parent product in the next method
+    if (!$product || $product instanceof \WC_Product_Variation) {
       return $label_string;
     }
 

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1030,7 +1030,7 @@ class WooCommerce {
       return '';
     }
 
-    $back_in_stock_date = get_post_meta($product->get_id(), self::FIELD_BACK_IN_STOCK_DATE, TRUE) ?? '';
+    $back_in_stock_date = get_post_meta($product->get_id(), self::FIELD_BACK_IN_STOCK_DATE, TRUE);
     if(empty($back_in_stock_date)){
       return '';
     }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1063,9 +1063,7 @@ class WooCommerce {
    * @implements woocommerce_de_get_deliverytime_string_label_string
    */
   public static function woocommerce_de_get_deliverytime_string_label_string($label_string, $product) {
-    // Avoid the execution of this function for product variants which can be
-    // evaluated over the parent product in the next method
-    if (!$product || $product instanceof \WC_Product_Variation) {
+    if (!$product) {
       return $label_string;
     }
 


### PR DESCRIPTION
### Ticket
https://app.asana.com/0/784106262441860/1201312032738062/f

### Description
The problem was the amount of times the function woocommerce_de_get_deliverytime_string_label_string was been called in the listing pages, triggering even more subqueries from it, at least ny removing the Product Variation objects from the calling stack I was able to reduce the local page loading by more than half... 

I refactored also the function to format the back in stock date which was doing an extra condition to make sure the date was a valid future date when the it has been done in the previous step in all cases. 
