### PR TITLE
Fixed express delivery filter cannot be disabled.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -57,7 +57,8 @@ class Plugin {
     $active_plugins = apply_filters('active_plugins', get_option('active_plugins'));
     if (in_array('woocommerce-german-market/WooCommerce-German-Market.php', $active_plugins)) {
       // Registers products filter widgets supporting delivery time.
-      add_action('widgets_init', __NAMESPACE__ . '\ProductFilters\DeliveryTime::widgets_init');
+      // Ensures the hook is called with a higher priority than others to work.
+      add_action('widgets_init', __NAMESPACE__ . '\ProductFilters\DeliveryTime::widgets_init', 99);
 
       if (!is_admin()) {
         // Adds custom query variable to filter products by delivery time.

--- a/src/ProductFilters/DeliveryTime.php
+++ b/src/ProductFilters/DeliveryTime.php
@@ -7,7 +7,7 @@ namespace Netzstrategen\ShopStandards\ProductFilters;
  */
 class DeliveryTime {
 
-  const DELIVERY_TIME_VAR = 'delivery_time';
+  const HTTP_QUERY_NAME = 'delivery_time';
 
   /**
    * Registers products filter widgets supporting delivery time.

--- a/src/ProductFilters/DeliveryTime.php
+++ b/src/ProductFilters/DeliveryTime.php
@@ -7,6 +7,8 @@ namespace Netzstrategen\ShopStandards\ProductFilters;
  */
 class DeliveryTime {
 
+  const DELIVERY_TIME_VAR = 'delivery_time';
+
   /**
    * Registers products filter widgets supporting delivery time.
    *
@@ -80,13 +82,11 @@ class DeliveryTime {
    *   Content modified to include given query parameter.
    */
   public static function addFilterToNavLinks(string $html_filter, string $filter_name): string {
-    if ($filter_args = $_GET[$filter_name] ?? []) {
-      $filter_args = array_filter(array_map('absint', explode(',', wp_unslash($filter_args))));
-    }
-    // Return early if filter is currently not active.
-    if (!$filter_args) {
+    if (!$filter_args = $_GET[$filter_name] ?? []) {
+      // Return early if filter is currently not active.
       return $html_filter;
     }
+    $filter_args = array_filter(array_map('absint', explode(',', wp_unslash($filter_args))));
     // Add query parameter to all found hrefs.
     $html_filter = preg_replace_callback('@href="(.+?[^"])"@', function ($match) use ($filter_name, $filter_args) {
       $link = 'href="' . esc_url(add_query_arg($filter_name, implode(',', $filter_args), $match[1])) . '"';

--- a/src/ProductFilters/WidgetLayeredNavFilters.php
+++ b/src/ProductFilters/WidgetLayeredNavFilters.php
@@ -27,7 +27,7 @@ class WidgetLayeredNavFilters extends \WC_Widget_Layered_Nav_Filters {
     parent::widget($args, $instance);
     $output = ob_get_clean();
     // Return the original widget output when no delivery time is present.
-    if (!isset($_GET[DeliveryTime::DELIVERY_TIME_VAR])) {
+    if (!isset($_GET[DeliveryTime::HTTP_QUERY_NAME])) {
       echo $output;
       return;
     }
@@ -40,8 +40,8 @@ class WidgetLayeredNavFilters extends \WC_Widget_Layered_Nav_Filters {
       $this->widget_end($args);
       $output = ob_get_clean();
     }
-    $output = DeliveryTime::addFilterToNavLinks($output, DeliveryTime::DELIVERY_TIME_VAR);
-    $filter_values = array_filter(array_map('absint', explode(',', wp_unslash($_GET[DeliveryTime::DELIVERY_TIME_VAR]))));
+    $output = DeliveryTime::addFilterToNavLinks($output, DeliveryTime::HTTP_QUERY_NAME);
+    $filter_values = array_filter(array_map('absint', explode(',', wp_unslash($_GET[DeliveryTime::HTTP_QUERY_NAME]))));
     $delivery_times = WidgetFilterDeliveryTime::getProductsDeliveryTimes();
     $delivery_times = wp_list_pluck($delivery_times, 'name', 'term_id');
     $links = [];
@@ -49,10 +49,10 @@ class WidgetLayeredNavFilters extends \WC_Widget_Layered_Nav_Filters {
       // Ensures the applied time filter exists and is valid.
       if ($name = $delivery_times[$filter_value] ?? FALSE) {
         if ($values = array_diff($filter_values, [$filter_value])) {
-          $link = add_query_arg(DeliveryTime::DELIVERY_TIME_VAR, implode(',', $values));
+          $link = add_query_arg(DeliveryTime::HTTP_QUERY_NAME, implode(',', $values));
         }
         else {
-          $link = remove_query_arg(DeliveryTime::DELIVERY_TIME_VAR);
+          $link = remove_query_arg(DeliveryTime::HTTP_QUERY_NAME);
         }
         $links[] = '<li class="chosen"><a rel="nofollow" aria-label="' . esc_attr__('Remove filter', 'woocommerce') . '" href="' . esc_url($link) . '">' . $name . '</a></li>';
       }


### PR DESCRIPTION
### Ticket
https://app.asana.com/0/1200981693019240/1201452351682360

### Description
For some reason the same code shared between Gaco and Wopa, the widgets were being registered in a different order on this last one, which was causing a malfunction, so increasing the hook priority seem to be fine again, I took the chance to remove some clear redundancy in the code in order to improve any future maintenance. 
