### PR TITLE
Fixed duplicate sale labels after updating woocommerce-german-market.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -91,9 +91,9 @@ class Plugin {
     }
 
     // Displays sale price as regular price if custom field is checked.
-    add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_price_html', 10, 2);
+    add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_price_html', 20, 2);
     // Adds strike price (range) labels for variable products, too.
-    add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_variation_price_html', 10, 2);
+    add_filter('woocommerce_get_price_html', __NAMESPACE__ . '\WooCommerce::woocommerce_get_variation_price_html', 20, 2);
     // Remove "From" text prefixed to prices by B2B Market plugin (starting v1.0.6.1).
     add_filter('bm_original_price_html', __NAMESPACE__ . '\WooCommerce::b2b_remove_prefix', 10, 2);
 

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -84,7 +84,7 @@ class WooCommerce {
    * @implements bm_original_price_html
    */
   public static function b2b_remove_prefix($html, $product_id) {
-    $html = preg_replace('@<span class="b2b-price-prefix">.[^<]*</span>@', '', $html);
+    $html = preg_replace('@<span class="b2b-price-prefix">.[^<]*?</span>@', '', $html);
     return $html;
   }
 
@@ -699,12 +699,6 @@ class WooCommerce {
         }
         $price = wc_price(wc_get_price_to_display($product)) . $product->get_price_suffix();
       }
-      // Invoke regular price_html filters (excluding this one).
-      $current_filter = current_filter();
-      $priority = has_filter($current_filter, __METHOD__);
-      remove_filter($current_filter, __METHOD__);
-      $price = apply_filters($current_filter, $price, $product);
-      add_filter($current_filter, __METHOD__, $priority, 2);
 
       if (is_product() && !static::isSideProduct()) {
         $price_label = get_post_meta($product_id, self::FIELD_PRICE_LABEL, TRUE) ?: __('(Our price)', Plugin::L10N);


### PR DESCRIPTION
### Ticket
- https://app.asana.com/0/0/1201713901084428/f

### Description
- Original task that introduced the recursive call: https://app.asana.com/0/784106262441860/1136103500287444/f
