### PR TITLE
Fixed fatal error if woocommerce is not enabled.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -488,7 +488,7 @@ class WooCommerce {
    * @implements wp
    */
   public static function wp() {
-    if (empty($product = wc_get_product())) {
+    if (!is_callable('wc_get_product') || empty($product = wc_get_product())) {
       return;
     }
     $product_id = $product->get_id();

--- a/src/WooCommerceCheckout.php
+++ b/src/WooCommerceCheckout.php
@@ -132,7 +132,7 @@ class WooCommerceCheckout {
    */
   public static function isAmazonPayV2Checkout(): bool {
     $is_amazon_pay_active = is_plugin_active('woocommerce-gateway-amazon-payments-advanced/woocommerce-gateway-amazon-payments-advanced.php');
-    if ($is_amazon_pay_active && isset(WC()->session)) {
+    if ($is_amazon_pay_active && is_callable('WC') && isset(WC()->session)) {
       if (defined('WC_AMAZON_PAY_VERSION') && version_compare(WC_AMAZON_PAY_VERSION, '2.0', '>=') && !empty(WC()->session->get('amazon_checkout_session_id'))) {
         return true;
       }


### PR DESCRIPTION
Discovered during debugging of GACO updates.

Problem
- When disabling woocommerce to debug a certain behavior, then shop-standards causes a fatal error.

Unclear
- Not sure whether this is the best way. Maybe it is better to not register the hooks in init in the first place instead of checking in the individual callbacks.