### PR TITLE
Removed custom product brand schema output in favor of woocommerce-brands plugin.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -216,8 +216,6 @@ class Plugin {
 
     // Adds GTIN product number in schema.org.
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductGtin');
-    // Adds Brand name to schema.org.
-    add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductBrand');
     // Adds product variation price to schema.org.
     add_filter('woocommerce_structured_data_product_offer', __NAMESPACE__ . '\Seo::getProductVariationPrice', 10, 2);
     // Fixes schema.org prices according to tax settings.

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -182,22 +182,6 @@ class Seo {
   }
 
   /**
-   * Adds product brand to schema.org structured data.
-   *
-   * @implements woocommerce_structured_data_product
-   */
-  public static function getProductBrand($data) {
-    global $product;
-
-    $brand = get_the_terms($product->get_id(), apply_filters(Plugin::PREFIX . '_product_brand_taxonomy', 'pa_marken'));
-    if ($brand && !is_wp_error($brand)) {
-      $data['brand'] = $brand[0]->name;
-    }
-
-    return $data;
-  }
-
-  /**
    * Fixes schema.org prices according to tax settings.
    *
    * When retrieving product prices to add into schema.org woocommerce is not


### PR DESCRIPTION
[Specification of brand not added in schema markup on product pages](https://app.asana.com/0/30156186242982/1199997679462445)


