### PR TITLE
Fixed PHP fatal error caused by 'wpseo_canonical' filter.

### DIFF
--- a/src/ProductsPermalinks.php
+++ b/src/ProductsPermalinks.php
@@ -30,8 +30,8 @@ class ProductsPermalinks {
   /**
    * Ensures the canonical url matches the same product link fixed.
    */
-  public static function match_canonical_url(string $canonical): string {
-    if (is_product()) {
+  public static function match_canonical_url(?string $canonical): string {
+    if ($canonical && is_product()) {
       // Executes the same flow to get the right product link.
       $canonical = get_the_permalink();
     }


### PR DESCRIPTION
### Ticket
- [Fatal error when creating Woo Feeds](https://app.asana.com/0/784106262441860/1201457208483018/f)
