### PR TITLE
Fixed structured markup for brand missing on product detail pages.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -226,6 +226,8 @@ class Plugin {
 
     // Adds GTIN product number in schema.org.
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductGtin');
+    // Adds Brand name to schema.org.
+    add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductBrand');
     // Adds product variation price to schema.org.
     add_filter('woocommerce_structured_data_product_offer', __NAMESPACE__ . '\Seo::getProductVariationPrice', 10, 2);
     // Fixes schema.org prices according to tax settings.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -227,7 +227,8 @@ class Plugin {
     // Adds GTIN product number in schema.org.
     add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductGtin');
     // Adds Brand name to schema.org.
-    add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductBrand');
+    // Only if woocommerce-brands is not installed (using priority 20).
+    add_filter('woocommerce_structured_data_product', __NAMESPACE__ . '\Seo::getProductBrand', 21);
     // Adds product variation price to schema.org.
     add_filter('woocommerce_structured_data_product_offer', __NAMESPACE__ . '\Seo::getProductVariationPrice', 10, 2);
     // Fixes schema.org prices according to tax settings.

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -182,6 +182,22 @@ class Seo {
   }
 
   /**
+   * Adds product brand to schema.org structured data.
+   *
+   * @implements woocommerce_structured_data_product
+   */
+  public static function getProductBrand($data) {
+    global $product;
+
+    $brand = get_the_terms($product->get_id(), apply_filters(Plugin::PREFIX . '_product_brand_taxonomy', 'pa_marken'));
+    if ($brand && !is_wp_error($brand)) {
+      $data['brand'] = $brand[0]->name;
+    }
+
+    return $data;
+  }
+
+  /**
    * Fixes schema.org prices according to tax settings.
    *
    * When retrieving product prices to add into schema.org woocommerce is not

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -194,8 +194,8 @@ class Seo {
       return $data;
     }
 
-    $brand = get_the_terms($product->get_id(), apply_filters(Plugin::PREFIX . '_product_brand_taxonomy', 'pa_marken'));
-    if ($brand && !is_wp_error($brand)) {
+    $brands = get_the_terms($product->get_id(), apply_filters(Plugin::PREFIX . '_product_brand_taxonomy', 'pa_marken'));
+    if ($brands && !is_wp_error($brands)) {
       $data['brand'] = [
         '@type' => 'Brand',
         'name' => $brands[0]->name,

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -189,9 +189,17 @@ class Seo {
   public static function getProductBrand($data) {
     global $product;
 
+    // Delegate to woocommerce-brands plugin, if installed.
+    if (isset($data['brand'])) {
+      return $data;
+    }
+
     $brand = get_the_terms($product->get_id(), apply_filters(Plugin::PREFIX . '_product_brand_taxonomy', 'pa_marken'));
     if ($brand && !is_wp_error($brand)) {
-      $data['brand'] = $brand[0]->name;
+      $data['brand'] = [
+        '@type' => 'Brand',
+        'name' => $brands[0]->name,
+      ];
     }
 
     return $data;


### PR DESCRIPTION
### Ticket
- [Product: Structured brand schema.org data missing on product detail pages](https://app.asana.com/0/587433704548192/1202348023753929)

### Description
- 4678e6e647909a1815d22f109645db2ed97e217c removed the custom output in favor of the plugin woocommerce-brands, but WOPA/LAMP does not use the plugin.
- This PR restores the original output (and fixes the structured data), but only outputs it if the woocommerce-brands plugin is not installed.
