### PR TITLE
Fixed PHP Fatal error: Uncaught TypeError: Return value must be of type string, null returned.

### DIFF
--- a/src/ProductsPermalinks.php
+++ b/src/ProductsPermalinks.php
@@ -30,7 +30,7 @@ class ProductsPermalinks {
   /**
    * Ensures the canonical url matches the same product link fixed.
    */
-  public static function match_canonical_url(?string $canonical): string {
+  public static function match_canonical_url(?string $canonical): ?string {
     if ($canonical && is_product()) {
       // Executes the same flow to get the right product link.
       $canonical = get_the_permalink();


### PR DESCRIPTION
### Task
- [Various PHP Fatal errors, errors, warnings](https://app.asana.com/0/809933051638353/1202430764055301)

### Description
- https://github.com/netzstrategen/wordpress-shop-standards/pull/190 attempted to fix a fatal error due to an empty argument being passed, but did not take into account that the return type hint still declares a `string` to be returned (the argument passed from `wpseo_canonical` is `null`): https://github.com/netzstrategen/wordpress-shop-standards/blob/6a3a09c801df229b23b34f93f51762f49aad136d/src/ProductsPermalinks.php#L33-L38
