### PR TITLE
Fixed fatal error during checkout if customer does not create account.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -188,8 +188,8 @@ class Plugin {
     // Adds missing postcode validation for some countries.
     add_filter('woocommerce_validate_postcode', __NAMESPACE__ . '\WooCommerce::woocommerce_validate_postcode', 10, 3);
 
-    // Adds customer metafields when creating orders.
-    add_action('woocommerce_checkout_create_order', __NAMESPACE__ . '\WooCommerce::addCustomMetaForUser', 10, 1);
+    // Track counts of orders and order items for each customer.
+    add_action('woocommerce_checkout_create_order', __NAMESPACE__ . '\WooCommerceCheckout::woocommerce_checkout_create_order');
 
     if (class_exists('Woocommerce_German_Market')) {
       // Remove delivery time from product name in order emails, added by

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1513,39 +1513,4 @@ class WooCommerce {
     return $dropdown_values;
   }
 
-  /**
-   * Adds customer orders and items count to orders meta.
-   *
-   * @implements woocommerce_checkout_create_order
-   */
-  public static function addCustomMetaForUser(\WC_Order $order):void {
-    if (!$order) {
-     return;
-    }
-    $user_id = $order->get_user_id();
-    $items_counter = $order->get_item_count();
-    $customer_orders_count = get_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', TRUE);
-    $customer_order_items_count = get_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_order_items_count', TRUE);
-    if ($customer_orders_count && $customer_order_items_count) {
-      $customer_orders_count++;
-      $customer_order_items_count += $items_counter;
-    }
-    else {
-      $args = [
-        'limit' => -1,
-        'customer_id' => $user_id,
-      ];
-      $customer_orders = wc_get_orders($args);
-
-      foreach ($customer_orders as $customer_order) {
-        $items_counter += $customer_order->get_item_count();
-      }
-
-      $customer_orders_count = count($customer_orders) + 1;
-      $customer_order_items_count = $items_counter;
-    }
-    update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', $customer_orders_count);
-    update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_order_items_count', $customer_order_items_count);
-  }
-
 }

--- a/src/WooCommerceCheckout.php
+++ b/src/WooCommerceCheckout.php
@@ -150,4 +150,38 @@ class WooCommerceCheckout {
     return $fields;
   }
 
+  /**
+   * Tracks counts of orders and order items for each customer.
+   *
+   * @implements woocommerce_checkout_create_order
+   */
+  public static function woocommerce_checkout_create_order(\WC_Order $order): void {
+    if (!$order) {
+      return;
+    }
+    if (!$user_id = $order->get_user_id()) {
+      return;
+    }
+    $total_order_count = get_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', TRUE);
+    $total_order_items_count = get_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_order_items_count', TRUE);
+
+    if (!is_numeric($total_order_count)) {
+      $customer_orders = wc_get_orders([
+        'limit' => -1,
+        'customer_id' => $user_id,
+      ]);
+      $total_order_count = count($customer_orders);
+      $total_order_items_count = 0;
+      foreach ($customer_orders as $customer_order) {
+        $total_order_items_count += $customer_order->get_item_count();
+      }
+    }
+
+    $total_order_count++;
+    $total_order_items_count += $order->get_item_count()
+
+    update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', $total_order_count);
+    update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_order_items_count', $total_order_items_count);
+  }
+
 }

--- a/src/WooCommerceCheckout.php
+++ b/src/WooCommerceCheckout.php
@@ -156,10 +156,7 @@ class WooCommerceCheckout {
    * @implements woocommerce_checkout_create_order
    */
   public static function woocommerce_checkout_create_order(\WC_Order $order): void {
-    if (!$order) {
-      return;
-    }
-    if (!$user_id = $order->get_user_id()) {
+    if (!$order || !$user_id = $order->get_user_id()) {
       return;
     }
     $total_order_count = get_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', TRUE);

--- a/src/WooCommerceCheckout.php
+++ b/src/WooCommerceCheckout.php
@@ -178,7 +178,7 @@ class WooCommerceCheckout {
     }
 
     $total_order_count++;
-    $total_order_items_count += $order->get_item_count()
+    $total_order_items_count += $order->get_item_count();
 
     update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', $total_order_count);
     update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_order_items_count', $total_order_items_count);


### PR DESCRIPTION
Fixes a fatal error introduced by https://github.com/netzstrategen/wordpress-shop-standards/pull/214 (for [Add custom meta fields to orders](https://app.asana.com/0/1201940451841784/1202635304001298)) ([Slack thread](https://netzstrategen.slack.com/archives/CLGJ41RPW/p1662557855312009?thread_ts=1662553421.058559&cid=CLGJ41RPW))

### Description
- Lots of fatal errors are happening since last deployment on Monday and hundreds of orders were not be able to be placed.
- The new code to track counts of orders per customer assumes that every customer would always create a user account.  But anonymous checkouts are possible.
- This causes the code to load all orders that are associated with user ID 0 (a lot).
- In turn, the server runs out of memory, halting in a fatal error.

