### PR TITLE
Removed unnecessary orders count metafield.

### DIFF
--- a/src/WooCommerceCheckout.php
+++ b/src/WooCommerceCheckout.php
@@ -159,25 +159,21 @@ class WooCommerceCheckout {
     if (!$order || !$user_id = $order->get_user_id()) {
       return;
     }
-    $total_order_count = get_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', TRUE);
     $total_order_items_count = get_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_order_items_count', TRUE);
 
-    if (!is_numeric($total_order_count)) {
+    if (!is_numeric($total_order_items_count)) {
       $customer_orders = wc_get_orders([
         'limit' => -1,
         'customer_id' => $user_id,
       ]);
-      $total_order_count = count($customer_orders);
       $total_order_items_count = 0;
       foreach ($customer_orders as $customer_order) {
         $total_order_items_count += $customer_order->get_item_count();
       }
     }
 
-    $total_order_count++;
     $total_order_items_count += $order->get_item_count();
 
-    update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_orders_count', $total_order_count);
     update_user_meta($user_id, '_' . Plugin::PREFIX . '_customer_order_items_count', $total_order_items_count);
   }
 


### PR DESCRIPTION
### Ticket
- [Follow up on "Add custom meta fields to orders"](https://app.asana.com/0/1202867909936929/1202971033917628)

### Description
- Removed the code for _shop-standards_customer_orders_count
- The condition in the if was changed and not removed in order to make the wc_get_orders call only when the metafield is initially created.