### PR TITLE
feat: allow shop standard fields to be included/excluded from coupons

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -354,8 +354,8 @@ class Plugin {
       'title' => __('Shop standard fields to exclude from coupon', Plugin::L10N),
       'fields' => [
           [
-              'key' => 'field_6760319f700ef',
-              'name' => 'include-ssfields',
+              'key' => 'acf_shop_standard_coupon_validation',
+              'name' => 'acf_shop_standard_coupon_validation',
               'label' => __('Validate Shop standard field on coupon.',Plugin::L10N),              
               'type' => 'repeater',
               'layout' => 'table',
@@ -363,9 +363,9 @@ class Plugin {
               'button_label' => __('Add validation', Plugin::L10N),
               'sub_fields' => [
                 [
-                  'key' => 'acf_shop_standard_sub_field',
-                  'name' => 'acf_shop_standard_sub_field',
-                  'label' => 'Shop standard field',
+                  'key' => 'acf_shop_standard_product_field',
+                  'name' => 'acf_shop_standard_product_field',
+                  'label' => __('Shop standard product field', Plugin::L10N),
                   'type' => 'select',
                   'choices' => woocommerce::get_product_fields(),
                   'allow_null' => 0,
@@ -373,8 +373,8 @@ class Plugin {
                   'ui' => 1,
                 ],
                 [
-                  'key' => 'acf_shop_standard_include',
-                  'name' => 'acf_shop_standard_include',
+                  'key' => 'acf_shop_standard_include_or_exclude',
+                  'name' => 'acf_shop_standard_include_or_exclude',
                   'label' => __('Coupon validaton for field.', Plugin::L10N),
                   'type' => 'select',
                   'choices' => [

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -270,6 +270,9 @@ class Plugin {
       add_action('woocommerce_order_details_before_order_table', __NAMESPACE__ . '\WooCommerce::woocommerce_order_details_before_order_table');
     }
 
+    // Exclude coupon for producs with custom shopstandards fields marked as exclude.
+    add_filter('woocommerce_coupon_get_discount_amount', __NAMESPACE__ . '\WooCommerce::apply_product_shop_standard_field_validations_to_coupon',11,5);
+
   }
 
   /**
@@ -344,6 +347,56 @@ class Plugin {
       'label_placement' => 'top',
       'instruction_placement' => 'label',
       'active' => 1,
+    ]);
+    
+    acf_add_local_field_group([
+      'key' => 'acf_shop_standard_coupon_exclude',
+      'title' => __('Shop standard fields to exclude from coupon', Plugin::L10N),
+      'fields' => [
+          [
+              'key' => 'field_6760319f700ef',
+              'name' => 'include-ssfields',
+              'label' => __('Validate Shop standard field on coupon.',Plugin::L10N),              
+              'type' => 'repeater',
+              'layout' => 'table',
+              'instructions' => __('List of shop standard fields to validate.', Plugin::L10N),
+              'button_label' => __('Add validation', Plugin::L10N),
+              'sub_fields' => [
+                [
+                  'key' => 'acf_shop_standard_sub_field',
+                  'name' => 'acf_shop_standard_sub_field',
+                  'label' => 'Shop standard field',
+                  'type' => 'select',
+                  'choices' => woocommerce::get_product_fields(),
+                  'allow_null' => 0,
+                  'multiple' => 0,
+                  'ui' => 1,
+                ],
+                [
+                  'key' => 'acf_shop_standard_include',
+                  'name' => 'acf_shop_standard_include',
+                  'label' => __('Coupon validaton for field.', Plugin::L10N),
+                  'type' => 'select',
+                  'choices' => [
+                      'INCLUDE' => 'INCLUDE',
+                      'EXCLUDE' => 'EXCLUDE',
+                  ],                  
+                  'allow_null' => 0,
+                  'multiple' => 0,
+                  'ui' => 1,
+                ],
+              ],
+          ],
+      ],
+      'location' => [
+          [
+              [
+                  'param' => 'post_type',
+                  'operator' => '==',
+                  'value' => 'shop_coupon',
+              ],
+          ],
+      ],      
     ]);
   }
 

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1578,7 +1578,7 @@ class WooCommerce {
             // Get sub field values.
             $acf_shop_standards_product_field = $field['acf_shop_standard_product_field']; 
             $included_or_excluded = $field['acf_shop_standard_include_or_exclude']; 
-            Var_dump($acf_shop_standards_product_field."-->".$included_or_excluded);
+            
             if($included_or_excluded === 'EXCLUDE'){
               $exclude_shop_standard_fields[] = $acf_shop_standards_product_field;
               $are_coupon_fields_marked_excluded=true;

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1548,4 +1548,50 @@ class WooCommerce {
     }
   }
 
+  /**
+   * Validates if the product cart item has a field marked as EXCLUDE in the coupon and applies the discount accordingly.
+   *
+   * @return int Discount value for the cart item.
+   */
+  public static function apply_product_shop_standard_field_validations_to_coupon($discount, $discounting_amount, $cart_item, $single, $coupon) {
+    
+    // Gets the coupon id.
+    $coupon_id = $coupon->get_id();
+
+    // Gets the repeater 'include-ssfields' value list.
+    $shop_standards_fields = get_field('include-ssfields', $coupon_id);
+    
+    $exclude_shop_standard_fields = [];
+
+    // Gets the shop standard fields of the coupon marked as EXCLUDE.
+    if (!empty($shop_standards_fields) && is_array($shop_standards_fields)) {
+        foreach ($shop_standards_fields as $field) {
+            // Get sub field values.
+            $shop_standard_field = $field['acf_shop_standard_sub_field']; 
+            $include = $field['acf_shop_standard_include']; 
+            
+            if($include === 'EXCLUDE'){
+              $exclude_shop_standard_fields[] = $shop_standard_field;
+            }            
+        }
+    } 
+   
+    // Get product fields matching with coupon fields marked as EXCLUDE.
+    $product_id = $cart_item['product_id'];
+    $product = wc_get_product($product_id);
+    $product_fields = [];
+    
+    foreach ($exclude_shop_standard_fields as $field) {
+      $product_shop_standard_field=$product->get_meta($field,true);
+      if($product_shop_standard_field && wc_string_to_bool($product_shop_standard_field)){
+        $product_fields[] = $field;
+      }     
+    }
+   
+    if (!empty($product_fields)) {
+      return 0;
+    }
+    return $discount;
+  }
+
 }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1558,8 +1558,8 @@ class WooCommerce {
     // Gets the coupon id.
     $coupon_id = $coupon->get_id();
 
-    // Gets the repeater 'include-ssfields' value list.
-    $shop_standards_fields = get_field('include-ssfields', $coupon_id);
+    // Gets the repeater 'acf_shop_standard_coupon_validation' value list.
+    $shop_standards_fields = get_field('acf_shop_standard_coupon_validation', $coupon_id);
     
     $exclude_shop_standard_fields = [];
 
@@ -1567,11 +1567,11 @@ class WooCommerce {
     if (!empty($shop_standards_fields) && is_array($shop_standards_fields)) {
         foreach ($shop_standards_fields as $field) {
             // Get sub field values.
-            $shop_standard_field = $field['acf_shop_standard_sub_field']; 
-            $include = $field['acf_shop_standard_include']; 
+            $acf_shop_standards_product_field = $field['acf_shop_standard_product_field']; 
+            $included_or_excluded = $field['acf_shop_standard_include_or_exclude']; 
             
-            if($include === 'EXCLUDE'){
-              $exclude_shop_standard_fields[] = $shop_standard_field;
+            if($included_or_excluded === 'EXCLUDE'){
+              $exclude_shop_standard_fields[] = $acf_shop_standards_product_field;
             }            
         }
     } 


### PR DESCRIPTION
… include or exclude.

### Ticket
- [Allow Shop Standards fields to be included/excluded for coupons](https://app.asana.com/0/inbox/1207137008813182/1208930858883854/1208995547501464)

### Description
- Create AFC repeater to mark shop standards fields to include or exclude from coupon
- Validate cart items to apply the discount only to those with no shop standard fields marked as excluded.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208976405989624