### PR TITLE
fix: avoid product permalink canonical redirect loops

### DIFF
--- a/src/ProductsPermalinks.php
+++ b/src/ProductsPermalinks.php
@@ -49,9 +49,13 @@ class ProductsPermalinks {
    * permalink instead.
    */
   public static function redirect_to_product_permalink(): void {
+    if (!is_product()) {
+      return;
+    }
+
     remove_action('template_redirect', 'wc_product_canonical_redirect', 5);
 
-    if (!is_product() || !function_exists('wc_get_product')) {
+    if (!function_exists('wc_get_product')) {
       return;
     }
 

--- a/src/ProductsPermalinks.php
+++ b/src/ProductsPermalinks.php
@@ -53,7 +53,10 @@ class ProductsPermalinks {
       return;
     }
 
-    remove_action('template_redirect', 'wc_product_canonical_redirect', 5);
+    $woocommerce_canonical_priority = has_action('template_redirect', 'wc_product_canonical_redirect');
+    if ($woocommerce_canonical_priority !== FALSE) {
+      remove_action('template_redirect', 'wc_product_canonical_redirect', $woocommerce_canonical_priority);
+    }
 
     if (!function_exists('wc_get_product')) {
       return;
@@ -65,13 +68,15 @@ class ProductsPermalinks {
     }
 
     $request_path = wp_parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
-    if (!$request_path) {
+    $product_path = wp_parse_url($product->get_permalink(), PHP_URL_PATH);
+    if (!$request_path || !$product_path) {
       return;
     }
 
-    $current_url = trailingslashit(home_url($request_path));
+    $current_path = trailingslashit($request_path);
+    $product_path = trailingslashit($product_path);
     $product_url = trailingslashit($product->get_permalink());
-    if ($current_url === $product_url) {
+    if ($current_path === $product_path) {
       return;
     }
 

--- a/src/ProductsPermalinks.php
+++ b/src/ProductsPermalinks.php
@@ -21,6 +21,7 @@ class ProductsPermalinks {
     if (get_option(self::FIELD_ENFORCE_CAT_LINKS)) {
       add_filter('post_type_link', __CLASS__ . '::get_product_permalink', PHP_INT_MAX, 2);
       add_filter('wpseo_canonical', __CLASS__ . '::match_canonical_url', PHP_INT_MAX);
+      add_action('template_redirect', __CLASS__ . '::redirect_to_product_permalink', 4);
     }
     // Set up admin actions to handle product setting.
     add_action('admin_init', __CLASS__ . '::register_product_settings');
@@ -36,6 +37,43 @@ class ProductsPermalinks {
       $canonical = get_the_permalink();
     }
     return $canonical;
+  }
+
+  /**
+   * Redirects product requests to the enforced product permalink.
+   *
+   * WooCommerce's product canonical redirect compares the requested category
+   * against the full category hierarchy, while this plugin intentionally emits
+   * product permalinks with only the main category slug. Remove WooCommerce's
+   * redirect to avoid self-redirect loops, then compare against the filtered
+   * permalink instead.
+   */
+  public static function redirect_to_product_permalink(): void {
+    remove_action('template_redirect', 'wc_product_canonical_redirect', 5);
+
+    if (!is_product() || !function_exists('wc_get_product')) {
+      return;
+    }
+
+    $product = wc_get_product(get_the_ID());
+    if (!$product) {
+      return;
+    }
+
+    $request_path = wp_parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+    if (!$request_path) {
+      return;
+    }
+
+    $current_url = trailingslashit(home_url($request_path));
+    $product_url = trailingslashit($product->get_permalink());
+    if ($current_url === $product_url) {
+      return;
+    }
+
+    $query_vars = isset($_GET) && is_array($_GET) ? $_GET : [];
+    wp_safe_redirect(add_query_arg($query_vars, $product_url), 301);
+    exit;
   }
 
   /**


### PR DESCRIPTION
This pull request enhances the product permalink enforcement logic by adding a custom redirect to ensure product URLs always use the intended format, and prevents redirect loops with WooCommerce's default behavior.

**Permalink enforcement and redirect logic:**

* Added a new `redirect_to_product_permalink` method in `ProductsPermalinks.php` to redirect product requests to the enforced permalink, ensuring URLs use only the main category slug and preventing self-redirect loops. This method removes WooCommerce's default canonical redirect before performing its own check and redirect.
* Registered the new redirect action in `init()` by hooking `redirect_to_product_permalink` to the `template_redirect` action when category links enforcement is enabled.