### PR TITLE
feat: expose cart item metadata for the Cart block collapsible

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -953,6 +953,10 @@ class WooCommerce {
     $separator = [[
       'key' => 'separator',
       'value' => '',
+      // Hide the split marker in the Cart/Checkout blocks, which render item
+      // data client-side and would otherwise print a literal "separator:" row.
+      // The classic cart template still finds this entry and splits on it.
+      '__experimental_woocommerce_blocks_hidden' => TRUE,
     ]];
 
     // Display delivery time from woocommerce-german-market first for each order item.
@@ -972,6 +976,15 @@ class WooCommerce {
     else {
       $data = array_merge($data, $separator);
     }
+
+    // Tag each attribute row with our own class. The Cart block copies an
+    // item-data entry's `className` onto its rendered <li>, giving a
+    // progressive-enhancement script a stable hook to group these rows under a
+    // collapsible toggle. The classic cart template ignores the extra key.
+    $filtered_attributes = array_map(static function ($attribute) {
+      $attribute['className'] = 'shop-standards-attribute--additional';
+      return $attribute;
+    }, $filtered_attributes);
 
     // Add product data (SKU, dimensions and weight) and attributes.
     // Note: we display parent attributes for production variations.


### PR DESCRIPTION
## What

In `WooCommerce::woocommerce_get_item_data()`:

1. Tag each product-attribute row with a `className` of `shop-standards-attribute--additional`.
2. Mark the synthetic `separator` entry with `__experimental_woocommerce_blocks_hidden => true`.

## Why

The store is migrating the cart from the classic `[woocommerce_cart]` shortcode to the **WooCommerce Cart block**. The block renders line-item metadata client-side (React, from the Store API) — it ignores PHP templates like `cart-item-data.php`, so:

- the internal `separator` marker leaked into the block as a literal `separator:` row, and
- the classic template's collapsible "Produkteigenschaften" section (which splits the metadata at `separator`) was lost.

The Cart block copies an item-data entry's `className` onto its rendered `<li>`, and honours `__experimental_woocommerce_blocks_hidden`. Tagging the rows here gives a small frontend enhancement (registered via the official `IntegrationInterface` in the project's `custom` plugin) a **stable, self-owned hook** to group the attributes behind a collapsible toggle — no DOM scraping, no reliance on WooCommerce-internal classes.

## Compatibility

The classic cart template is unaffected: it ignores both extra keys and still splits the list on the `separator` entry. Verified end-to-end on the block cart (attributes collapse/expand, no flash, survives Store API re-renders) with WooCommerce 10.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)